### PR TITLE
Course referencing style change

### DIFF
--- a/Curriculum.md
+++ b/Curriculum.md
@@ -107,7 +107,7 @@
 ### Notes
 
 - This is a rather modern theoretical topic which is the backbone of many systems we commonly use. Database books are also not available in as much variety as the other topics.
-- [*TYCS*](https://teachyourselfcs.com/#databases) recommends going through [video lectures from Berkeley](https://archive.org/details/UCBerkeley_Course_Computer_Science_186) before textbooks.
+- [TYCS](https://teachyourselfcs.com/#databases) recommends going through [video lectures from Berkeley](https://archive.org/details/UCBerkeley_Course_Computer_Science_186) before textbooks.
 
 <a id="DMS" href="#DMSref">^</a>1 - Used as the reference for
 
@@ -128,7 +128,7 @@
 - [15-445/645 at CMU](https://15445.courses.cs.cmu.edu/fall2017/)
 - [CS 348 at UoW](https://cs.uwaterloo.ca/~david/cs348/) along with [^](#DMS)1
 
-<a id="TDRB" href="#TDRBref">^</a>3 - It is the recommended book on [*TYCS*](https://teachyourselfcs.com/#databases). Used as the reference for
+<a id="TDRB" href="#TDRBref">^</a>3 - It is the recommended book on [TYCS](https://teachyourselfcs.com/#databases). Used as the reference for
 
 - [ECS 165A at UC Davis](http://web.cs.ucdavis.edu/~green/courses/ecs165a-w11/)
 
@@ -323,7 +323,7 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 - [CS 157 at Brown](https://cs.brown.edu/courses/cs157/)
 
-<a id="ADM" href="#ADMref">^</a>4 - Recommended by [*TYCS*](https://teachyourselfcs.com/#algorithms). Used as the reference for
+<a id="ADM" href="#ADMref">^</a>4 - Recommended by [TYCS](https://teachyourselfcs.com/#algorithms). Used as the reference for
 
 - [CSE 373 at SUNY, SB](http://www3.cs.stonybrook.edu/~skiena/373/) which is taken by **Steven Skiena**
 
@@ -405,7 +405,7 @@ There are plenty more books than listed and more courses than I'd care to link.
 - [TOM-2.1-CS at UT](https://wwwhome.ewi.utwente.nl/~pieter/CS-OS/)
 - [CS 372 at UT Austin](http://www.cs.utexas.edu/users/witchel/372/) although certain readings are from [^](#TDB)1 as well.
 
-<a id="OSTEP" href="#OSTEPref">^</a>3 - [**OSTEP**](http://pages.cs.wisc.edu/~remzi/OSTEP/) was made as a companion for [CS 537 at UWISC](http://pages.cs.wisc.edu/~remzi/Classes/537/Spring2018/), which is freely available. The professors also recommend reading classic texts such as **Linux Kernel Development** and **The C Programming Language** (K&R). It is also used as a reference for [WPI's CS 3013](https://web.cs.wpi.edu/~cshue/cs3013/). Apart from being my personal recommendation for an introduction to Operating Systems, it is also recommended over at [_TYCS_](https://teachyourselfcs.com/#operating-systems).
+<a id="OSTEP" href="#OSTEPref">^</a>3 - [**OSTEP**](http://pages.cs.wisc.edu/~remzi/OSTEP/) was made as a companion for [CS 537 at UWISC](http://pages.cs.wisc.edu/~remzi/Classes/537/Spring2018/), which is freely available. The professors also recommend reading classic texts such as **Linux Kernel Development** and **The C Programming Language** (K&R). It is also used as a reference for [WPI's CS 3013](https://web.cs.wpi.edu/~cshue/cs3013/). Apart from being my personal recommendation for an introduction to Operating Systems, it is also recommended over at [TYCS](https://teachyourselfcs.com/#operating-systems).
 
 <a id="OSPP" href="#OSPPref">^</a>4 - Used as the reference for
 
@@ -808,16 +808,16 @@ Online courses about Microprocessors are rather difficult to come by.
    [What are the canon books in Computer Science? - /r/COMPSCI](https://www.reddit.com/r/compsci/comments/40mq3q/what_are_the_canon_books_in_computer_science/)  
    [What Books Should Everyone Read? - Theoretical Computer Science Stack Exchange](https://cstheory.stackexchange.com/questions/3253/what-books-should-everyone-read)  
    [What papers should everyone read? - Theoretical Computer Science Stack Exchange](https://cstheory.stackexchange.com/questions/1168/what-papers-should-everyone-read?noredirect=1&lq=1)  
-   [Data Structures - Further reading](https://en.wikipedia.org/wiki/Data_structure#Further_reading)  
-   [Database - Further reading](https://en.wikipedia.org/wiki/Database#Further_reading)
-   [Programming Language - Further reading](https://en.wikipedia.org/wiki/Programming_language#Further_reading)  
-   [Microarchitecture - Further reading](https://en.wikipedia.org/wiki/Microarchitecture#Further_reading)  
-   [Algorithms - Further reading](https://en.wikipedia.org/wiki/Algorithm#Further_reading)  
-   [Theory of Computation - Further reading](https://en.wikipedia.org/wiki/Theory_of_computation#Further_reading)  
-   [Automata Theory - Further reading](https://en.wikipedia.org/wiki/Automata_theory#Further_reading)  
-   [Operating System - Further reading](https://en.wikipedia.org/wiki/Operating_system#Futher_reading)  
-   [Computer Network - Further Reading](https://en.wikipedia.org/wiki/Computer_network#Further_reading)
-   [Principles of Compiler Design -Further Reading]( https://en.wikipedia.org/wiki/Principles_of_Compiler_Design#Further_reading)
+   [Data Structures - Further Reading](https://en.wikipedia.org/wiki/Data_structure#Further_reading)  
+   [Database - Further Reading](https://en.wikipedia.org/wiki/Database#Further_reading)  
+   [Programming Language - Further Reading](https://en.wikipedia.org/wiki/Programming_language#Further_reading)  
+   [Microarchitecture - Further Reading](https://en.wikipedia.org/wiki/Microarchitecture#Further_reading)  
+   [Algorithms - Further Reading](https://en.wikipedia.org/wiki/Algorithm#Further_reading)  
+   [Theory of Computation - Further Reading](https://en.wikipedia.org/wiki/Theory_of_computation#Further_reading)  
+   [Automata Theory - Further Reading](https://en.wikipedia.org/wiki/Automata_theory#Further_reading)  
+   [Operating System - Further Reading](https://en.wikipedia.org/wiki/Operating_system#Futher_reading)  
+   [Computer Network - Further Reading](https://en.wikipedia.org/wiki/Computer_network#Further_reading)  
+   [Principles of Compiler Design - Further Reading]( https://en.wikipedia.org/wiki/Principles_of_Compiler_Design#Further_reading)  
    [List of Important Publications in Computer Science](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science)  
    [Discrete Mathematics - Further Reading](https://en.wikipedia.org/wiki/Discrete_mathematics#Further_reading)  
    [Discrete Mathematics - Wikibooks](https://en.wikibooks.org/wiki/Discrete_Mathematics)  
@@ -1016,8 +1016,8 @@ Online courses about Microprocessors are rather difficult to come by.
 
 - Compiler Design
 
-   [CS143 at Stanford University](https://web.stanford.edu/class/cs143/)
-   [CS4120 at Cornell University](http://www.cs.cornell.edu/courses/cs4120/2013fa/)
+   [CS143 at Stanford University](https://web.stanford.edu/class/cs143/)  
+   [CS4120 at Cornell University](http://www.cs.cornell.edu/courses/cs4120/2013fa/)  
    [CS5470 at university of Utah](https://courses.engr.illinois.edu/cs421/fa2014/)
 
 - Computer Networks
@@ -1089,7 +1089,7 @@ Online courses about Microprocessors are rather difficult to come by.
    [**Information Theory, Inference, and Learning Algorithms**](http://www.inference.org.uk/mackay/itila/book.html) by David J. C. Mackay  
    [2011 Workshop on Complexity Information Theory in Theoretical Computer Science and Discrete Mathematics](http://sites.math.rutgers.edu/~saks/IT/)  
    [A Mathematical Theory of Communication - Claude Shannon (1948)](math.harvard.edu/~ctm/home/text/others/shannon/entropy/entropy.pdf)  
-   [Awesome Compilers - GitHub](https://github.com/aalhour/awesome-compilers)
+   [Awesome Compilers - GitHub](https://github.com/aalhour/awesome-compilers)  
    [Introduction to Software Engineering - Wikibooks](https://en.wikibooks.org/wiki/Introduction_to_Software_Engineering)  
    [Software Engineering book by Ivan Marsic](http://www.ece.rutgers.edu/~marsic/books/SE/book-SE_marsic.pdf)  
    [Supplementary Material for **Object-Oriented Software Engineering**](http://www.site.uottawa.ca/school/research/lloseng/) by Lethbridge and Laganière  

--- a/Curriculum.md
+++ b/Curriculum.md
@@ -22,17 +22,17 @@
 
 1. **Introduction to Data Structures with Applications** - Jean P. Tremblay and Paul G. Sorenson
 2. **Data Structures and Algorithms** - Alfred V. Aho, John E. Hopcroft and Jeffrey D. Ullman
-3. **Data Abstraction and Problem Solving with C++: Walls and Mirrors** - Frank M. Carrano [1]
+3. **Data Abstraction and Problem Solving with C++: Walls and Mirrors** - Frank M. Carrano <sup id="DAPSCref">[[1]](#DAPSC)</sup>
 
 ### Alternative/Supplementary
 
 1. **Data Structures and Algorithm Analysis in C** - Mark Allen Weiss
-2. **Algorithms in Java** - Robert Sedgewick [2]
-3. **Data Structures and Algorithms in Java** - M. Goodrich, R. Tamassia, and M. Goldwasser [3]
-4. **Data Structures and Algorithms Analysis in Java** - Mark Allen Weiss [4]
-5. **Data Structures: Abstraction and Design Using Java** - Elliot B. Koffman and Paul A. T. Wolfgang [5]
-6. **An Introduction to Programming through C++** - Abhiram G. Ranade [6]
-7. **ADTs, Data Structures and Problem Solving** - Larry Nyhoff [7]
+2. **Algorithms in Java** - Robert Sedgewick <sup id="AiJref">[[2]](#AiJ)</sup>
+3. **Data Structures and Algorithms in Java** - M. Goodrich, R. Tamassia, and M. Goldwasser <sup id="DSAJref">[[3]](#DSAJ)</sup>
+4. **Data Structures and Algorithms Analysis in Java** - Mark Allen Weiss <sup id="DSAAJref">[[4]](#DSAAJ)</sup>
+5. **Data Structures: Abstraction and Design Using Java** - Elliot B. Koffman and Paul A. T. Wolfgang <sup id="DSADUJref">[[5]](#DSADUJ)</sup>
+6. **An Introduction to Programming through C++** - Abhiram G. Ranade <sup id="IPCPPref">[[6]](#IPCPP)</sup>
+7. **ADTs, Data Structures and Problem Solving** - Larry Nyhoff <sup id="ADSPSref">[[7]](#ADSPS)</sup>
 8. **Data Structures, Algorithms and Applications in C++** - Sartaj Sahani
 9. **Data Structures and Algorithms: Concepts, Techniques and Applications** - G. A. V. Pai
 10. **Data Structures** - D. Samanta
@@ -53,32 +53,32 @@
 - [CS 61BL at Berkeley](https://sp18.datastructur.es/) uses a [set of free notes](https://joshhug.gitbooks.io/hug61b/) by the instructor for the first half, and **Algorithms** by Sedgewick and Wayne for the second half.
 - [Data Structures and Algorithms (Level 1/C) at UoB](http://www.cs.bham.ac.uk/~jxb/dsa.html) recommends using 3 free ebooks linked on the course page.
 
-[1] - Used as a reference for
+<a id="DAPSC" href="#DAPSCref">^</a>1 - Used as a reference for
 
 - [CS 302 at UNR](https://www.cse.unr.edu/~mgunes/cs302/cs302fa12/) but covers only Data Structures and also assumes prior background in Algorithms
 
-[2] - Used as a reference for
+<a id="AiJ" href="#AiJref">[2]</a> - Used as a reference for
 
 - [CS 226 at Princeton](https://www.cs.princeton.edu/~rs/AlgsDS07/) which is **Sedgewick's own course**
 
-[3] - Used as a reference for
+<a id="DSAJ" href="#DSAJref">^</a>3 - Used as a reference for
 
 - [CSE 2010 at FIT](https://cs.fit.edu/~pkc/classes/ds/)
 
-[4] - Used as a reference for
+<a id="DSAAJ" href="#DSAAJref">^</a>4 - Used as a reference for
 
 - [600.226 at JHU](http://www.cs.jhu.edu/~hager/Teaching/cs226/)
 - [CS 315 at UT Austin](http://www.cs.utexas.edu/users/novak/cs315.html) a set of lecture notes [hosted online](https://www.cs.utexas.edu/users/novak/cs315contents.html) are the primary material
 
-[5] - Used as a reference for
+<a id="DSADUJ" href="#DSADUJref">^</a>5 - Used as a reference for
 
 - [CS 206 at BMC](https://cs.brynmawr.edu/cs206/)
 
-[6] - Used as a reference for
+<a id="IPCPPref" href="#IPCPP">^</a>6 - Used as a reference for
 
 - [CS 213(M) at IIT Bombay](https://www.cse.iitb.ac.in/~ranade/cs213/) which is taken by **Ranade**
 
-[7] - Used as a reference for
+<a id="ADSPS" href="#ADSPSref">^</a>7 - Used as a reference for
 
 - [CS 240 at BU](http://www.cs.binghamton.edu/~steflik/cs240/cs240.htm) but covers only Data Structures
 
@@ -533,7 +533,7 @@ Online courses about Microprocessors are rather difficult to come by.
 
 [4] - Used as the reference for
 
-- [Discrete Structures and Combinatorics at BGU](https://www.cs.bgu.ac.il/~dsc172/Main) along with some weird Israeli book? :shrug
+- [Discrete Structures and Combinatorics at BGU](https://www.cs.bgu.ac.il/~dsc172/Main) along with some weird Israeli book? :shrug:
 
 [5] - Used as the reference for
 
@@ -756,7 +756,7 @@ Online courses about Microprocessors are rather difficult to come by.
 ### Notes
 
 - Wikipedia has a [list of notable publications](https://en.wikipedia.org/wiki/Outline_of_software_engineering#Notable_publications) in Software Engineering.
-- [CS32 at Brown](http://cs.brown.edu/courses/cs0320/) recommends **Effective Java** by Joshua Bloch for some reason. :shrug
+- [CS32 at Brown](http://cs.brown.edu/courses/cs0320/) recommends **Effective Java** by Joshua Bloch for some reason. :shrug:
 - [EE 360F at UT Austin](http://users.ece.utexas.edu/~perry/education/SE-Intro/) has a list of papers and sections from multiple books as necessary readings for the course.
 
 [1] - Used as the reference for

--- a/Curriculum.md
+++ b/Curriculum.md
@@ -181,7 +181,7 @@
 - [601.426/626 at JHU](http://pl.cs.jhu.edu/pl/index.shtml) use their own book created by a course instructor. The book itself is available under Creative Commons License [here](http://pl.cs.jhu.edu/pl/book/book.pdf).
 - An extensive list of resources can also be found at [Programming Language Theory](http://steshaw.org/plt/).
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [CS 6848 at IIT, Madras](https://www.cse.iitm.ac.in/~krishna/courses/2015/odd-cs6848/) along with [5], with [2] and [9] for additional reference
 - [Principles of Programming Languages at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/principles/)
@@ -190,35 +190,35 @@
 - [CS704 at UWISC](https://github.com/barghouthi/cs704) and has a number of other recommendations as well
 - [CSCI 3155 at Berkeley](http://csci3155.cs.colorado.edu/s18/) but the recommended readings are from notes with a bunch of other resources linked
 
-[2] - Please make sure to go through the [errata listed](http://theory.stanford.edu/people/jcm/books/cpl-errata.html) when using this book. Used as the reference for
+<a id="" href="#">^</a>2 - Please make sure to go through the [errata listed](http://theory.stanford.edu/people/jcm/books/cpl-errata.html) when using this book. Used as the reference for
 
 - [CS 59 at Dartmouth](http://www.cs.dartmouth.edu/~sergey/cs59/syllabus.pdf) is a syllabus only page with many other materials on the instructor's website and also uses some material from <sup id="">[[7]](#)</sup>
 - [CSCI 334 at WC](http://www.cs.williams.edu/~dbarowy/cs334s18/)
 
-[4] - Used as the reference for
+<a id="" href="#">^</a>4 - Used as the reference for
 
 - [CS 245 at BMC](https://cs.brynmawr.edu/Courses/cs245/fall2010/)
 - [CSc 520 at UAT](https://www2.cs.arizona.edu/classes/cs520/spring06/)
 - [CSCI 3136 at Dal](https://web.cs.dal.ca/~nzeh/Teaching/3136/index.html) which also recommends reading [7], [2], [10] and **The Cinderella Book**
 
-[6] - Used as the reference for
+<a id="" href="#">^</a>6 - Used as the reference for
 
 - [COMP 411 at RU](https://www.cs.rice.edu/~javaplt/411/14-spring/)
 
-[8] - Used as the reference for
+<a id="" href="#">^</a>8 - Used as the reference for
 
 - [CSC 272 at AU](https://home.adelphi.edu/~siegfried/cs272/)
 - [CS 3MI3 at MMU](http://www.cas.mcmaster.ca/~franek/courses/cs3mi3/)
 
-[9] - Used as the reference for
+<a id="" href="#">^</a>9 - Used as the reference for
 
 - [15-312 at CMU](https://www.cs.cmu.edu/~jcr/tpl.html)
 
-[11] - Used as the reference for
+<a id="" href="#">^</a>11 - Used as the reference for
 
 - [CMSC 245 at HC](https://www.haverford.edu/computer-science/course-pages/2016f-cmsc-245-principles-programming-languages) (Note: Syllabus page only)
 
-[12] - Used as the reference for
+<a id="" href="#">^</a>12 - Used as the reference for
 
 - [TIE-20306 at TUT](http://www.cs.tut.fi/~popl/nykyinen/index.shtml) along with a free *Finnish* textbook
 
@@ -248,11 +248,11 @@
 
 There are plenty more books than listed and more courses than I'd care to link.
 
-[1] - Widely regarded as an authoritative reference for Computer Organisation and Architecture. It is written by Turing Award winning Computer Scientists David Patterson and John Hennessy, but also assumes the reader is already well versed with concepts of Computer Architecture. For the beginner, [2] is widely recommended as _the_ book to start with. Used as a reference for
+<a id="" href="#">^</a>1 - Widely regarded as an authoritative reference for Computer Organisation and Architecture. It is written by Turing Award winning Computer Scientists David Patterson and John Hennessy, but also assumes the reader is already well versed with concepts of Computer Architecture. For the beginner, [2] is widely recommended as _the_ book to start with. Used as a reference for
 
 - [CS146 at Harvard](http://www.eecs.harvard.edu/~dbrooks/cs146-spring2004/)
 
-[2] - [TYCS](https://teachyourselfcs.com/#architecture) recommends this excellent book (after going through **The Elements of Computing Systems** by Nishan and Schocken), as do I, for an introduction to the fundamental ideas of Computer Organisation and Architecture. It is extremely well written, has plenty of depth, and is built upon in [1] by the same authors. Used as a reference for
+<a id="" href="#">^</a>2 - [TYCS](https://teachyourselfcs.com/#architecture) recommends this excellent book (after going through **The Elements of Computing Systems** by Nishan and Schocken), as do I, for an introduction to the fundamental ideas of Computer Organisation and Architecture. It is extremely well written, has plenty of depth, and is built upon in [1] by the same authors. Used as a reference for
 
 - [CS 312 at UMSL](http://www.cs.umsl.edu/~sanjiv/classes/cs312/)
 - [ECE 411 at UI](https://ece.illinois.edu/academics/courses/profile/ECE411)
@@ -261,9 +261,9 @@ There are plenty more books than listed and more courses than I'd care to link.
 - [CS 3410 at Cornell](http://www.cs.cornell.edu/courses/cs3410/2016fa/)
 - [CS 61C at Berkeley](http://www-inst.eecs.berkeley.edu/%7Ecs61c/sp15/#Resources)
 
-[4] - I didn't find this book stimulating at all.
+<a id="" href="#">^</a>4 - I didn't find this book stimulating at all.
 
-[6] - I found this book incredibly dull and difficult to understand. Good luck.
+<a id="" href="#">^</a>6 - I found this book incredibly dull and difficult to understand. Good luck.
 
 [7] - Used as the reference for
 
@@ -271,7 +271,7 @@ There are plenty more books than listed and more courses than I'd care to link.
 - [15-213/18-213 at CMU](http://www.cs.cmu.edu/%7E213/)
 - [CS107 at Stanford](http://web.stanford.edu/class/cs107/)
 
-[9] - Used as the reference for
+<a id="" href="#">^</a>9 - Used as the reference for
 
 - [EE382 at Stanford](https://web.stanford.edu/class/ee382/)
 
@@ -305,13 +305,13 @@ There are plenty more books than listed and more courses than I'd care to link.
 - [Algorithms, Etc. by Jeff Erickson](http://jeffe.cs.illinois.edu/teaching/algorithms/) is a set of notes that covers the material necessary for his course at University of Illinois.
 - *TAOCP* also serves as a useful reference for many algorithms typically studied as part of an undergraduate level course. It is quite mathematical so typically many students find it a hard read.
 
-[1] - Typically used as an encyclopedic reference for most topic, rather than an introduction to algorithms. Used as the reference for
+<a id="" href="#">^</a>1 - Typically used as an encyclopedic reference for most topic, rather than an introduction to algorithms. Used as the reference for
 
 - [CS 600 A at SIT](https://www.cs.stevens.edu/~swetzel/CS600/spring11/)
 - [15-451/651 at CMU](https://www.cs.cmu.edu/~15451/) which also recommends [3] but either can be used, while an [older version](http://www.cs.cmu.edu/~avrim/451f09/index.html) has it's own set of notes
 - [CS 466/666 at UoW](https://cs.uwaterloo.ca/~eblais/courses/F17/CS466/) with additional material described [here](https://cs.uwaterloo.ca/~eblais/courses/F17/CS466/outline.pdf)
 
-[2] - Used as the reference for
+<a id="" href="#">^</a>2 - Used as the reference for
 
 - [CSci 256 at WC](https://www.cs.williams.edu/~lenhart/cs256/index.html)
 - [CPSC500 at UBC](http://www.cs.ubc.ca/~condon/cpsc500/) with [3] additionally recommended along with other texts
@@ -319,15 +319,15 @@ There are plenty more books than listed and more courses than I'd care to link.
 - [CS 161 at Stanford](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms) where Tim has made his lecture videos available to all
 - [CS 7820 at Cornell](http://www.cs.cornell.edu/courses/cs6820/2009fa/) taken by **Jon Kleinberg**
 
-[3] - Used as the reference for
+<a id="" href="#">^</a>3 - Used as the reference for
 
 - [CS 157 at Brown](https://cs.brown.edu/courses/cs157/)
 
-[4] - Recommended by *TYCS*. Used as the reference for
+<a id="" href="#">^</a>4 - Recommended by *TYCS*. Used as the reference for
 
 - [CSE 373 at SUNY, SB](http://www3.cs.stonybrook.edu/~skiena/373/) which is taken by **Steven Skiena**
 
-[5] - Used as the reference for
+<a id="" href="#">^</a>5 - Used as the reference for
 
 - [COS226 at Princeton](http://www.cs.princeton.edu/courses/archive/spring18/cos226/) with a [condensed version of the book](https://algs4.cs.princeton.edu/home/) available for reference
 
@@ -354,20 +354,20 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Notes
 
-[1] - Used a reference textbook for many courses around the world. It closely matches what Jeff Ullman [teaches online at Lagunita](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about). (Duh)
+<a id="" href="#">^</a>1 - Used a reference textbook for many courses around the world. It closely matches what Jeff Ullman [teaches online at Lagunita](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about). (Duh)
 
-[2] - Used as the reference for
+<a id="" href="#">^</a>2 - Used as the reference for
 
 - [CS 3102 at UoV](http://www.cs.virginia.edu/~robins/cs3102/)
 - [CS-251 at EPFL](http://theory.epfl.ch/cs251/Home.html)
 - [CS 3800 at NEU](https://course.ccs.neu.edu/cs3800f17wc/policies.html)
 - [CS39 at Dartmouth](https://www.cs.dartmouth.edu/~ac/Teach/CS39-Spring18/)
 
-[4] - Used as the reference for
+<a id="" href="#">^</a>4 - Used as the reference for
 
 - [UPenn's CSC 4170-50](https://www.seas.upenn.edu/~cit596/notes/dave/syllabus.html)
 
-[5] - Used as the reference for
+<a id="" href="#">^</a>5 - Used as the reference for
 
 - [AU's COMP 674](http://www.athabascau.ca/syllabi/comp/comp674.php), a graduate level course.
 
@@ -394,7 +394,7 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Operating_systems) provides a list of a series of breakthroughs in Operating System Design. [A list of research papers on Udacity](https://www.udacity.com/wiki/ud156-readings) may also be useful, and are the recommended readings for [CS 6210 at GATech](https://www.omscs.gatech.edu/cs-6210-advanced-operating-systems).
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [CS 385 at UIC](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems/)
 - [CM's 15-410](https://www.cs.cmu.edu/~410/)
@@ -402,23 +402,23 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 - [Drexel's CS 543](https://www.cs.drexel.edu/~jjohnson/2012-13/fall/cs543/) which again recommends reading **Linux Kernel Development**.
 - [CS170 at UCSB](http://www.cs.ucsb.edu/~rich/class/cs170/)
 
-[2] - Used as the reference for
+<a id="" href="#">^</a>2 - Used as the reference for
 
 - [TOM-2.1-CS at UT](https://wwwhome.ewi.utwente.nl/~pieter/CS-OS/)
 - [CS 372 at UT Austin](http://www.cs.utexas.edu/users/witchel/372/) although certain readings are from [1] as well.
 
-[3] - [**OSTEP**](http://pages.cs.wisc.edu/~remzi/OSTEP/) was made as a companion for a [course on Operating Systems at UWISC](http://pages.cs.wisc.edu/~remzi/Classes/537/Spring2018/), which is freely available. The professors also recommend reading classic texts such as **Linux Kernel Development** and **The C Programming Language** (K&R). It is also used as a reference for [WPI's CS 3013](https://web.cs.wpi.edu/~cshue/cs3013/). Apart from being my personal recommendation for an introduction to Operating Systems, it is also recommended over at [Teach Yourself Computer Science](https://teachyourselfcs.com/£oeprating-systems) (_TYCS_).
+<a id="" href="#">^</a>3 - [**OSTEP**](http://pages.cs.wisc.edu/~remzi/OSTEP/) was made as a companion for a [course on Operating Systems at UWISC](http://pages.cs.wisc.edu/~remzi/Classes/537/Spring2018/), which is freely available. The professors also recommend reading classic texts such as **Linux Kernel Development** and **The C Programming Language** (K&R). It is also used as a reference for [WPI's CS 3013](https://web.cs.wpi.edu/~cshue/cs3013/). Apart from being my personal recommendation for an introduction to Operating Systems, it is also recommended over at [Teach Yourself Computer Science](https://teachyourselfcs.com/£oeprating-systems) (_TYCS_).
 
-[4] - Used as the reference for
+<a id="" href="#">^</a>4 - Used as the reference for
 
 - [SU's CS140](http://web.stanford.edu/~ouster/cgi-bin/cs140-spring18/index.php)
 - [Yale's CS422/522](http://flint.cs.yale.edu/cs422/)
 
-[5] - Used as the reference for
+<a id="" href="#">^</a>5 - Used as the reference for
 
 - [CS 161 at HU](http://www.eecs.harvard.edu/~cs161/)
 
-[6] - Basically a cheaper version of [1] recommended as the reference textbook for [CU's COMS W4118](http://www.cs.columbia.edu/~jae/4118/).
+<a id="" href="#">^</a>6 - Basically a cheaper version of [1] recommended as the reference textbook for [CU's COMS W4118](http://www.cs.columbia.edu/~jae/4118/).
 
 ## Data Communication
 <!-- Data transmission fundamentals: historical overview; time/frequency representation of data signals; elements of a communications link; definition of key terms; factors affecting system design, Binary and multi-level signaling: information transfer rate; calculation of channel capacity; bandwidth efficiency, Baseband data transmission: the problem of inter symbol interference; achieving a Nyquist channel response; recovery of symbols from noise; bit error rate performance for baseband data systems, Bandpass digital modulation: binary modulation schemes (eg ASK, FSK, PSK); multi-level digital modulation (e.g. M-ary ASK, M-ary FSK, M-ary PSK, QAM), Coding theory and practice: source coding; channel coding; block coding; convolutional coding; combined coding and modulation, Multi-user digital modulation techniques such as frequency division multiple access (FDMA); time division multiple access (TDMA); code division multiple access (CDMA); combined multiple access systems; Error detection and correction, Digital transmission fundamental  -->
@@ -438,7 +438,7 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 - Please help. I found nothing on the web with similar syllabus, which has been commented out. See source code.
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [CS 3413 at UTSA](http://www.cs.utsa.edu/~korkmaz/teaching/cs3413/)
 
@@ -463,11 +463,11 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 Online courses about Microprocessors are rather difficult to come by.
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [a course at UCF](http://www.cs.ucf.edu/~ahossam/teaching/microp/)
 
-[5] - Used as the reference for
+<a id="" href="#">^</a>5 - Used as the reference for
 
 - [IITK's CS43003](http://www.facweb.iitkgp.ernet.in/~apal/files/microprocessor_04.pdf) (Note: Syllabus page only)
 
@@ -515,7 +515,7 @@ Online courses about Microprocessors are rather difficult to come by.
 - Cornell also hosts a useful set of [notes on Discrete Structures](https://www.cs.cornell.edu/~rafael/discmath.pdf).
 - [UT Austin's CS 311](http://www.cs.utexas.edu/~vl/teaching/311/) appears to have their own set of lecture notes linked on the course page.
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [CS381 at ODU](http://www.cs.odu.edu/~cs381/index.html)
 - [CSE 191 at UaB](https://cse.buffalo.edu/~rapaport/191/) with [11] additionally recommended
@@ -525,33 +525,33 @@ Online courses about Microprocessors are rather difficult to come by.
 - [CS 70 at Berkeley](http://eecs70.org/) although notes are recommended for primary reading
 - [CS 207 at IIT Bombay](https://www.cse.iitb.ac.in/~akshayss/courses/cs207-2016.html) along with <sup id="">[[9]](#)</sup>
 
-[3] - Used as the reference for
+<a id="" href="#">^</a>3 - Used as the reference for
 
 - [CS2102 at UoV](https://uvacs2102.github.io/) and has generously been made [available online](https://uvacs2102.github.io/docs/mcs.pdf) under the Creative Commons License
 - [CS1010 at IITH](https://www.iith.ac.in/~aravind/cs1010.html) although it uses [slightly older notes](https://www.iith.ac.in/~aravind/Files-DM/LLM-MFCS-2012.pdf) instead with an additional guide on [**How to write Mathematics**](http://erickson.sites.truman.edu/files/2012/04/guide1.pdf) by Martin Erickson
 - [CS 30 at Dartmouth](https://www.cs.dartmouth.edu/~ac/Teach/CS30-Winter18/) with [1] recommended for additional reading
 
-[4] - Used as the reference for
+<a id="" href="#">^</a>4 - Used as the reference for
 
 - [Discrete Structures and Combinatorics at BGU](https://www.cs.bgu.ac.il/~dsc172/Main) along with some weird Israeli book? :shrug:
 
-[5] - Used as the reference for
+<a id="" href="#">^</a>5 - Used as the reference for
 
 - [CPS 102 at Duke](https://www2.cs.duke.edu/courses/spring09/cps102/) with [1], [6] and [7] also recommended
 
-[8] - Used as the reference for
+<a id="" href="#">^</a>8 - Used as the reference for
 
 - [MAT 385 at NKU](http://ceadserv1.nku.edu/longa//classes/2002fall/mat385/)
 
-[9] - Used as the reference for
+<a id="" href="#">^</a>9 - Used as the reference for
 
 - [Discrete Math at Cambridge](https://www.cl.cam.ac.uk/teaching/1314/DiscMath/) with additional books listed
 
-[10] - Used as the reference for
+<a id="" href="#">^</a>10 - Used as the reference for
 
 - [Discrete Mathematics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/discretemaths/) along with other recommendations like [^](#)4
 
-[12] - Used as the reference for
+<a id="" href="#">^</a>12 - Used as the reference for
 
 - [CSCI 2824 at UoC Boulder](https://www.colorado.edu/cs/csci-2824-discrete-structures)
 
@@ -586,7 +586,7 @@ Online courses about Microprocessors are rather difficult to come by.
 
 - There is a reference book for OpenGL programming one may find useful called the "[Red Book](http://www.opengl.org/documentation/red_book/)". Many courses have further resources like these linked on their course or info pages.
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [CSCI 1230 at Brown](https://cs.brown.edu/courses/cs123/)
 - [CS4620/CS4621 at Cornell](http://www.cs.cornell.edu/courses/cs4620/2014fa/index.shtml) along with [16]
@@ -594,17 +594,17 @@ Online courses about Microprocessors are rather difficult to come by.
 - [Introduction to Computer Graphics at UIC](https://www.cs.uic.edu/~jbell/CourseNotes/ComputerGraphics/index.html)
 - [CS 488 at UIC](https://www.evl.uic.edu/aej/488/index.html) which seems to be an earlier version of the course above
 
-[2] - Used as the reference for
+<a id="" href="#">^</a>2 - Used as the reference for
 
 - [CMU 15-462/662](http://15462.courses.cs.cmu.edu/fall2015/) along with [1] and <sup id="">[[8]](#)</sup>
 - [Computer Graphics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/graphics/) with [1] and others additionally recommended
 - [CS248 at Stanford](http://graphics.stanford.edu/courses/cs248-18-spring/) with [1] also recommended
 
-[16] - Used as the reference for
+<a id="" href="#">^</a>16 - Used as the reference for
 
 - [CS 175 at Harvard](https://sites.fas.harvard.edu/~lib175/) taught by Steven Gortler himself
 
-[17] - Used as the reference for
+<a id="" href="#">^</a>17 - Used as the reference for
 
 - [CS 465 at Bilkent](http://www.cs.bilkent.edu.tr/~gudukbay/cs465/)
 - [EDAF80 at LTH](http://cs.lth.se/edaf80/) with [The Graphics Codex](http://graphicscodex.com/) linked for additional reading
@@ -637,7 +637,7 @@ Online courses about Microprocessors are rather difficult to come by.
 - Most of the courses strongly recommend reading through Claude Shannon's [A Mathematical Theory of Communication](math.harvard.edu/~ctm/home/text/others/shannon/entropy/entropy.pdf) paper from 1948. It serves as the basis for the branch of Information Theory and Coding related research.
 - Most/All of the courses have relevant additional resources which are very useful
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [15-859 at CMU](http://www.cs.cmu.edu/~venkatg/teaching/ITCS-spr2013/) with many other classic papers recommended for reading
 - [CSE 533 at UoW](https://catalyst.uw.edu/workspace/anuprao/15415/86593) with [a list of papers](https://catalyst.uw.edu/workspace/anuprao/15415/86644)
@@ -653,7 +653,7 @@ Online courses about Microprocessors are rather difficult to come by.
 - [EECS 428 at NWU](https://www.mccormick.northwestern.edu/eecs/courses/descriptions/428.html) (Note: Syllabus page only)
 - [ECE 563 at UoI](https://ece.illinois.edu/academics/courses/profile/ece563) (Note: Syllabus page only)
 
-[2] - Used as a reference for
+<a id="" href="#">^</a>2 - Used as a reference for
 
 - [COMP 7404 at DU](http://web.cs.du.edu/~ramki/courses/tpcs/infoTheory/index.html)
 - [CSC 310 at UoT](https://www.cs.toronto.edu/~radford/csc310.F11/) with [3] recommended for rigorous mathematical analysis
@@ -675,13 +675,13 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Notes
 
-[1] - This is a brilliant book recommended by [pearson.com](https://www.pearson.com/us/higher-education/program/Aho-Compilers-Principles-Techniques-and-Tools-2nd-Edition/PGM167067.html). Used as the reference for
+<a id="" href="#">^</a>1 - This is a brilliant book recommended by [pearson.com](https://www.pearson.com/us/higher-education/program/Aho-Compilers-Principles-Techniques-and-Tools-2nd-Edition/PGM167067.html). Used as the reference for
 
 - [CS143 at Stanford University](https://web.stanford.edu/class/cs143/)
 - [CS4120 at Cornell University](http://www.cs.cornell.edu/courses/cs4120/2013fa/)
 - [CS5470 at university of Utah](https://courses.engr.illinois.edu/cs421/fa2014/)
 
-[2] - Used as reference for
+<a id="" href="#">^</a>2 - Used as reference for
 
 - [CS421 at University of Illinois](https://courses.engr.illinois.edu/cs421/fa2014/)
 
@@ -707,26 +707,26 @@ Online courses about Microprocessors are rather difficult to come by.
 
 [GATech's CS 6250](https://www.omscs.gatech.edu/cs-6250-computer-networks) has a list of useful papers [on Udacity](https://www.udacity.com/wiki/ud819/resources). There are also many more amazing resources on the web.
 
-[1] - It is recommended over at [TYCS](https://teachyourselfcs.com/#networking). Also used as the reference for
+<a id="" href="#">^</a>1 - It is recommended over at [TYCS](https://teachyourselfcs.com/#networking). Also used as the reference for
 
 - [CS60 at Dartmouth](http://www.cs.dartmouth.edu/~campbell/cs60/) where texts on Shell Scripting like **A Practical Guide to Linux Commands, Editors, and Shell Programming** by Mark G. Sobell are also recommended
 - [CS 356 at UT Austin](http://www.cs.utexas.edu/users/lam/cs356/)
 - [COS 461 at Princeton](https://www.cs.princeton.edu/courses/archive/spring17/cos461/) along with [^](#)2
 - [CS244A at Stanford](http://web.stanford.edu/class/cs244a/)
 
-[2] - Used as the reference for
+<a id="" href="#">^</a>2 - Used as the reference for
 
 - [15-441 at CMU](https://www.cs.cmu.edu/~prs/15-441-F16/)
 - [Computer Networks at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/networks/) along with <sup id="">[[3]](#)</sup>
 - [CS 640 at UWISC](http://pages.cs.wisc.edu/~pb/cs640.html)
 
-[4] - Used as the reference for
+<a id="" href="#">^</a>4 - Used as the reference for
 
 - [CS 408 at SU](http://people.sabanciuniv.edu/levi/cs408/)
 
-[5] - It is regarded as the standard textbook in the field [according to Wikipedia](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Networking).
+<a id="" href="#">^</a>5 - It is regarded as the standard textbook in the field [according to Wikipedia](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Networking).
 
-[6], [7] - Widely recommended in many courses listed above for additional reading, especially those at Princeton, Stanford and UWISC.
+<a id="" href="#">^</a>6, [7] - Widely recommended in many courses listed above for additional reading, especially those at Princeton, Stanford and UWISC.
 
 ## Software Engineering
 
@@ -759,43 +759,43 @@ Online courses about Microprocessors are rather difficult to come by.
 - [CS32 at Brown](http://cs.brown.edu/courses/cs0320/) recommends **Effective Java** by Joshua Bloch for some reason. :shrug:
 - [EE 360F at UT Austin](http://users.ece.utexas.edu/~perry/education/SE-Intro/) has a list of papers and sections from multiple books as necessary readings for the course.
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [15-413 at CMU](https://www.cs.cmu.edu/~aldrich/courses/413/)
 - [CS 501 at Cornell](http://www.cs.cornell.edu/courses/cs501/2000FA/index.html) along with other classic books like **The Mythical Man Month** by Frederick Brooks
 
-[2] - Used as the reference for
+<a id="" href="#">^</a>2 - Used as the reference for
 
 - [Introduction to Software Engineering at PSU](http://www.csci.psu.edu/seminars/fallnotes/SWEintro.pdf) (Note: Syllabus page only)
 
-[3] - Used as the reference for
+<a id="" href="#">^</a>3 - Used as the reference for
 
 - [CS 320 at UMass](https://people.cs.umass.edu/~brun/class/2013Spring/CS320/)
 
-[4] - Used as the reference for
+<a id="" href="#">^</a>4 - Used as the reference for
 
 - [CS223 at Warwick](http://web.iitd.ac.in/~sumeet/sm.pdf) (Note: Syllabus and lecture pdf only)
 
-[5] - Used as the reference for
+<a id="" href="#">^</a>5 - Used as the reference for
 
 - [CS302 at Saylor Academy](https://learn.saylor.org/mod/page/view.php?id=686)
 
-[6] - Used as the reference for
+<a id="" href="#">^</a>6 - Used as the reference for
 
 - [CSE 403 at UoW](https://courses.cs.washington.edu/courses/cse403/)
 
 [7] - A [free book](http://www.ece.rutgers.edu/~marsic/books/SE/book-SE_marsic.pdf) written by the instructor of [ECE 14:332:452 at Rutgers](http://www.ece.rutgers.edu/~marsic/Teaching/SE/).
 
-[8] - Used as the reference for
+<a id="" href="#">^</a>8 - Used as the reference for
 
 - [CSE870 at MSU](http://www.cse.msu.edu/~cse870/index.php) along with many other articles from literature
 - [Foundations of Software Engineering at BGU](https://www.cs.bgu.ac.il/~fsen141/Main) along with many other textbooks
 
-[9] - Used as the reference for
+<a id="" href="#">^</a>9 - Used as the reference for
 
 - SEG 2100 at UoO which cannot be accessed. Instead the author provides supporting materials and other links [here](http://www.site.uottawa.ca/school/research/lloseng/).
 
-[10] - Used as the reference for
+<a id="" href="#">^</a>10 - Used as the reference for
 
 - [CSE2102 at UConn](http://www.engr.uconn.edu/~steve/Cse2102/cse2102.html)
 

--- a/Curriculum.md
+++ b/Curriculum.md
@@ -1,6 +1,6 @@
 # CS Curriculum Textbooks and References
 
-- [Data Structure and Algorithms](#data-structure-and-algorithms)
+- [Data Structures and Algorithms](#data-structures-and-algorithms)
 - [Database Management Systems](#database-management-systems)
 - [Principles of Programming Languages](#principles-of-programming-languages)
 - [Computer Organisation and Architecture](#computer-organisation-and-architecture)
@@ -57,7 +57,7 @@
 
 - [CS 302 at UNR](https://www.cse.unr.edu/~mgunes/cs302/cs302fa12/) but covers only Data Structures and also assumes prior background in Algorithms
 
-<a id="AiJ" href="#AiJref">[2]</a> - Used as a reference for
+<a id="AiJ" href="#AiJref">^</a>2 - Used as a reference for
 
 - [CS 226 at Princeton](https://www.cs.princeton.edu/~rs/AlgsDS07/) which is **Sedgewick's own course**
 
@@ -86,9 +86,9 @@
 
 ### Standard Textbooks
 
-1. **Database Management Systems** - Johannes Gehrke and Raghu Ramakrishnan [1]
-2. **Database System Concepts** - Abraham Silberschatz, Henry F. Korth & S. Sudarshan [2]
-3. **Readings in Database Systems** - Joseph M. Hellerstein and Michael Stonebraker (*The (Databases) Red Book*) [3]
+1. **Database Management Systems** - Johannes Gehrke and Raghu Ramakrishnan <sup id="">[[1]](#)</sup>
+2. **Database System Concepts** - Abraham Silberschatz, Henry F. Korth & S. Sudarshan <sup id="">[[2]](#)</sup>
+3. **Readings in Database Systems** - Joseph M. Hellerstein and Michael Stonebraker (*The (Databases) Red Book*) <sup id="">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
@@ -96,9 +96,9 @@
 2. **An Introduction to Database system** - B. Desai
 3. **An Introduction to Database Systems** - Christopher J. Date
 4. **Fundamentals of Database Systems** - R. Elmasri, S. Navathe, S. B. Navathe, R. Sunderraman
-5. **Database Systems: The Complete Book** - Hector Garcia-Molina, Jeffrey D. Ullman and Jennifer Widom [4]
+5. **Database Systems: The Complete Book** - Hector Garcia-Molina, Jeffrey D. Ullman and Jennifer Widom <sup id="">[[4]](#)</sup>
 6. **Transaction Processing: Concepts and Techniques** - Jim Gray and Andreas Reuter
-7. **A First Course in Database Systems** - Jeffrey Ullman and Jennifer Widom [5]
+7. **A First Course in Database Systems** - Jeffrey Ullman and Jennifer Widom <sup id="">[[5]](#)</sup>
 8. **Database Systems** - Carolyn E. Begg and Thomas M. Connolly
 9. **Database Concepts** - David M. Kroenke and David J. Auer
 10. **Physical Database Design: the database professional's guide to exploitingindexes, views, storage, and more** - T. Teorey, S. Lightstone and T. Nadeau
@@ -109,7 +109,7 @@
 - This is a rather modern theoretical topic which is the backbone of many systems we commonly use. Database books are also not available in as much variety as the other topics.
 - [*TYCS*](https://teachyourselfcs.com/#databases) recommends going through [video lectures from Berkeley](https://archive.org/details/UCBerkeley_Course_Computer_Science_186) before textbooks.
 
-[1] - Used as the reference for
+<a id="" href="#">^</a>1 - Used as the reference for
 
 - [CS 186 at Berkeley](http://www.cs186berkeley.net/home)
 - [CS 4320/4321 at Cornell](http://www.cs.cornell.edu/courses/cs4320/2008fa/)
@@ -122,21 +122,21 @@
 - [CS/SE 4347 at UT Dallas](https://www.utdallas.edu/~muratk/courses/undb07.html)
 - [CS662 at UoV](http://www.cs.virginia.edu/~son/cs662.s06/)
 
-[2] - Used as the reference for
+<a id="" href="#">^</a>2 - Used as the reference for
 
 - [CS 23500/33550 at UoC](https://www.classes.cs.uchicago.edu/archive/2017/winter/23500-1/syllabus.html) (Note: Syllabus page only)
 - [15-445/645 at CMU](https://15445.courses.cs.cmu.edu/fall2017/)
-- [CS 348 at UoW](https://cs.uwaterloo.ca/~david/cs348/) along with [1]
+- [CS 348 at UoW](https://cs.uwaterloo.ca/~david/cs348/) along with [^](#)1
 
-[3] - It is the recommended book on [*TYCS*](https://teachyourselfcs.com/#databases). Used as the reference for
+<a id="" href="#">^</a>3 - It is the recommended book on [*TYCS*](https://teachyourselfcs.com/#databases). Used as the reference for
 
 - [ECS 165A at UC Davis](http://web.cs.ucdavis.edu/~green/courses/ecs165a-w11/)
 
-[4] - Used as the reference for
+<a id="" href="#">^</a>4 - Used as the reference for
 
 - [CS145 at Stanford](http://web.stanford.edu/class/cs145/)
 
-[5] - Used as the reference for
+<a id="" href="#">^</a>5 - Used as the reference for
 
 - [CS x265 at VU](https://my.vanderbilt.edu/cs265/) but strongly recommends going through **Jennifer Widom's** self paced "Databases Course" on [Stanford Lagunita](https://lagunita.stanford.edu/courses/DB/2014/SelfPaced/about)
 
@@ -144,21 +144,21 @@
 
 ### Standard Textbooks
 
-1. **Essentials of Programming Languages** - Daniel P. Friedman, Mitchell Wand and Christopher T. Haynes (*EOPL*) [1]
-2. **Concepts in Programming Languages** - John C. Mitchell [2]
-3. **Programming Languages: Application and Interpretation** - S. Krishnamurthi (*PLAI*) [3]
+1. **Essentials of Programming Languages** - Daniel P. Friedman, Mitchell Wand and Christopher T. Haynes (*EOPL*) <sup id="">[[1]](#)</sup>
+2. **Concepts in Programming Languages** - John C. Mitchell <sup id="">[[2]](#)</sup>
+3. **Programming Languages: Application and Interpretation** - S. Krishnamurthi (*PLAI*) <sup id="">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **Programming Language Pragmatics** - Michael L. Scott [4]
-2. **Types and Programming Languages** - Benjamin C. Pierce (*TAPL*) [5]
-3. **A Formal Semantics of Programming Languages: An Introduction** - Glynn Winskel [6]
-4. **Structure and Interpretation of Computer Programs** -	Harold Abelson, Gerald Jay Sussman and Julie Sussman (*SICP*) [7]
-5. **Concepts of Programming Languages** - Robert W. Sebesta [8]
-6. **Practical Foundations of Programming Languages** - Robert Harper [9]
-7. **Programming Languages: Design and Implementation** - T. W. Prat & M. V. Zelkowitz [10]
-8. **Programming Languages: Principles & Practices** - Kenneth C. Louden [11]
-9. **Programming Languages: Principles and Paradigms** - Maurizio Gabbrielli and Simone Martini [12]
+1. **Programming Language Pragmatics** - Michael L. Scott <sup id="">[[4]](#)</sup>
+2. **Types and Programming Languages** - Benjamin C. Pierce (*TAPL*) <sup id="">[[5]](#)</sup>
+3. **A Formal Semantics of Programming Languages: An Introduction** - Glynn Winskel <sup id="">[[6]](#)</sup>
+4. **Structure and Interpretation of Computer Programs** -	Harold Abelson, Gerald Jay Sussman and Julie Sussman (*SICP*) <sup id="">[[7]](#)</sup>
+5. **Concepts of Programming Languages** - Robert W. Sebesta <sup id="">[[8]](#)</sup>
+6. **Practical Foundations of Programming Languages** - Robert Harper <sup id="">[[9]](#)</sup>
+7. **Programming Languages: Design and Implementation** - T. W. Prat & M. V. Zelkowitz <sup id="">[[10]](#)</sup>
+8. **Programming Languages: Principles & Practices** - Kenneth C. Louden <sup id="">[[11]](#)</sup>
+9. **Programming Languages: Principles and Paradigms** - Maurizio Gabbrielli and Simone Martini <sup id="">[[12]](#)</sup>
 10. **Programming Languages – Concepts & Constructs** - Ravi Sethi
 11. **Foundations for Programming Languages** - John C. Mitchell
 12. **The Lambda Calculus: Its Syntax and Semantics** - H. P. Barendregt
@@ -192,7 +192,7 @@
 
 [2] - Please make sure to go through the [errata listed](http://theory.stanford.edu/people/jcm/books/cpl-errata.html) when using this book. Used as the reference for
 
-- [CS 59 at Dartmouth](http://www.cs.dartmouth.edu/~sergey/cs59/syllabus.pdf) is a syllabus only page with many other materials on the instructor's website and also uses some material from [7]
+- [CS 59 at Dartmouth](http://www.cs.dartmouth.edu/~sergey/cs59/syllabus.pdf) is a syllabus only page with many other materials on the instructor's website and also uses some material from <sup id="">[[7]](#)</sup>
 - [CSCI 334 at WC](http://www.cs.williams.edu/~dbarowy/cs334s18/)
 
 [4] - Used as the reference for
@@ -226,23 +226,23 @@
 
 ### Standard Textbooks
 
-1. **Computer Architecture: A Quantitative Approach** - David A. Patterson and John L. Hennessy [1]
-2. **Computer Organisation and Design: The Hardware/Software Interface** - David A. Patterson and John L. Hennessy [2]
-3. **Computer Organisation** - V. C. Hamacher, Zvonko G. Vranesic and Safwat G. Zaky [3]
+1. **Computer Architecture: A Quantitative Approach** - David A. Patterson and John L. Hennessy <sup id="">[[1]](#)</sup>
+2. **Computer Organisation and Design: The Hardware/Software Interface** - David A. Patterson and John L. Hennessy <sup id="">[[2]](#)</sup>
+3. **Computer Organisation** - V. C. Hamacher, Zvonko G. Vranesic and Safwat G. Zaky <sup id="">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **Computer System Architecture** - M. Morris Mano [4]
-2. **Computer Organization and Architecture: Designing for Performance** - William Stallings [5]
-3. **Computer Architecture and Organisation** - John. P. Hayes [6]
+1. **Computer System Architecture** - M. Morris Mano <sup id="">[[4]](#)</sup>
+2. **Computer Organization and Architecture: Designing for Performance** - William Stallings <sup id="">[[5]](#)</sup>
+3. **Computer Architecture and Organisation** - John. P. Hayes <sup id="">[[6]](#)</sup>
 4. **Computer Systems Design and Architecture** - Vincent P Heuring and Harry F Jordan
 5. **Fundamentals of Computer Organization and Architecture** - Mostafa Abd-El-Barr and Hesham El-Rewini
-6. **Computer Systems: a Programmer’s Perspective** - Randal E. Bryant and David R. O’Hallaron [7]
-7. **Introduction to Computing Systems: From Bits and Gates to C and Beyond** - Patt and Patel [8]
+6. **Computer Systems: a Programmer’s Perspective** - Randal E. Bryant and David R. O’Hallaron <sup id="">[[7]](#)</sup>
+7. **Introduction to Computing Systems: From Bits and Gates to C and Beyond** - Patt and Patel <sup id="">[[8]](#)</sup>
 8. **Structured Computer Organization** - Andrew S. Tanenbaum
 9. **The Principles of Computer Hardware** - A. Clements
 10. **Fundamentals of Computer Architecture** - M. Burrell
-11. **Computer Architecture: Pipelined and Parallel Processor Design** - Michael J. Flynn [9]
+11. **Computer Architecture: Pipelined and Parallel Processor Design** - Michael J. Flynn <sup id="">[[9]](#)</sup>
 
 ### Notes
 
@@ -257,7 +257,7 @@ There are plenty more books than listed and more courses than I'd care to link.
 - [CS 312 at UMSL](http://www.cs.umsl.edu/~sanjiv/classes/cs312/)
 - [ECE 411 at UI](https://ece.illinois.edu/academics/courses/profile/ECE411)
 - [B62006Y-01 at ](http://english.ucas.ac.cn/index.php/admission/undergraduate/course-syllabuses/620-school-of-computer-and-control-engineering/4471-principles-of-computer-organization) (Note: Syllabus page only)
-- [18-447 at CMU](http://www.ece.cmu.edu/~ece447/s13/doku.php?id=schedule) along with [8]
+- [18-447 at CMU](http://www.ece.cmu.edu/~ece447/s13/doku.php?id=schedule) along with <sup id="">[[8]](#)</sup>
 - [CS 3410 at Cornell](http://www.cs.cornell.edu/courses/cs3410/2016fa/)
 - [CS 61C at Berkeley](http://www-inst.eecs.berkeley.edu/%7Ecs61c/sp15/#Resources)
 
@@ -279,15 +279,15 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Standard Textbooks
 
-1. **Introduction to Algorithms** - Thomas Cormen, C. Leiserson, and R. Rivest and C. Stein (*CLRS*) [1]
-2. **Algorithm Design** - Jon Kleinberg and Éva Tardos (*KT*) [2]
-3. **Algorithms** - Christos Papadimitriou, Sanjoy Dasgupta, and Umesh Vazirani (*DPV*) [3]
+1. **Introduction to Algorithms** - Thomas Cormen, C. Leiserson, and R. Rivest and C. Stein (*CLRS*) <sup id="">[[1]](#)</sup>
+2. **Algorithm Design** - Jon Kleinberg and Éva Tardos (*KT*) <sup id="">[[2]](#)</sup>
+3. **Algorithms** - Christos Papadimitriou, Sanjoy Dasgupta, and Umesh Vazirani (*DPV*) <sup id="">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **The Algorithm Design Manual** - Steven Skiena [4]
-2. **Algorithms** - Robert Sedgewick and Kevin Wayne [5]
-3. **Introduction to Algorithms: A Creative Approach** - Udi Manber [6]
+1. **The Algorithm Design Manual** - Steven Skiena <sup id="">[[4]](#)</sup>
+2. **Algorithms** - Robert Sedgewick and Kevin Wayne <sup id="">[[5]](#)</sup>
+3. **Introduction to Algorithms: A Creative Approach** - Udi Manber <sup id="">[[6]](#)</sup>
 4. **Fundamentals of Computer Algorithms** - Ellis Horowitz, Sartaj Sahni and S. Rajasekaran
 5. **An Introduction to the Analysis of Algorithms** - Robert Sedgewick and Philippe Flajolet
 6. **Design and Analysis of Algorithm** - P. H. Dave and H. B. Dave
@@ -335,13 +335,13 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Standard Textbooks
 
-1. **Introduction to Automata Theory, Languages, and Computation** - John E. Hopcroft and Jeffrey D. Ullman (_The Cinderella Book_) [1]
-2. **Introduction to the Theory of Computation** - Michael Sipser [2]
+1. **Introduction to Automata Theory, Languages, and Computation** - John E. Hopcroft and Jeffrey D. Ullman (_The Cinderella Book_) <sup id="">[[1]](#)</sup>
+2. **Introduction to the Theory of Computation** - Michael Sipser <sup id="">[[2]](#)</sup>
 3. **Elements of the Theory of Computation** - Harry R. Lewis & C. H. Papadimitriou
 
 ### Alternative/Supplementary
 
-1. **Introduction to Formal Language and Computation** - Peter Linz [4]
+1. **Introduction to Formal Language and Computation** - Peter Linz <sup id="">[[4]](#)</sup>
 2. **Theory of Computer Science: Automata, Language and Computation** - Mishra & Chandrasekharan
 3. **A Text Book on Automata Theory** - Nasir & Sirmani
 4. **Introduction to Languages and The Theory of Computation** - John Martin
@@ -375,20 +375,20 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Standard Textbooks
 
-1. **Operating System Concepts** - J. L. Peterson and A. Silberschatz (*The Dinosaur Book*) [1]
+1. **Operating System Concepts** - J. L. Peterson and A. Silberschatz (*The Dinosaur Book*) <sup id="">[[1]](#)</sup>
 2. **Modern Operating Systems** - Andrew S. Tanenbaum
-3. **Operating Systems, Internals and Design Principles** - William Stallings [2]
+3. **Operating Systems, Internals and Design Principles** - William Stallings <sup id="">[[2]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **Operating Systems: Three Easy Pieces** - Remzi H. Arpaci-Dusseau and Andrea C. Arpaci-Dusseau (*The Black Book*/*The Asteroid Book*/*The Comet Book*) [3]
+1. **Operating Systems: Three Easy Pieces** - Remzi H. Arpaci-Dusseau and Andrea C. Arpaci-Dusseau (*The Black Book*/*The Asteroid Book*/*The Comet Book*) <sup id="">[[3]](#)</sup>
 2. **Schaum’s Outline of Operating Systems** - Archer J. Harris
 3. **The Design of the UNIX operating system** - Maurice J. Bach
-4. **Operating Systems: Principles and Practice** - Thomas Anderson and Michael Dahlin. [4]
+4. **Operating Systems: Principles and Practice** - Thomas Anderson and Michael Dahlin. <sup id="">[[4]](#)</sup>
 5. **Operating Systems: A Concept-Based Approach** - D. M. Dhamdhere
 6. **Operating Systems: A Modern Perspective** - Gary J. Nutt
-7. **Operating Systems In Depth: Design and Programming** - Thomas W. Doeppner [5]
-8. **Operating System Concepts Essentials** - Silberschatz, Galvin, Gagne [6]
+7. **Operating Systems In Depth: Design and Programming** - Thomas W. Doeppner <sup id="">[[5]](#)</sup>
+8. **Operating System Concepts Essentials** - Silberschatz, Galvin, Gagne <sup id="">[[6]](#)</sup>
 
 ### Notes
 
@@ -431,7 +431,7 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 1. **Data Communication, Computer Networks and Open Systems** - Fred Halsall
 2. **TCP/IP Protocol Suite** - B. A. Forouzan
-3. **Data and Computer Communications** - William Stallings [1]
+3. **Data and Computer Communications** - William Stallings <sup id="">[[1]](#)</sup>
 4. **Communication Networks, Fundamental Concepts & Key Architecture** - Leon-Garcia and I. Widjaja
 
 ### Notes
@@ -446,9 +446,9 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 ### Standard Textbooks
 
-1. **The Intel Microprocessors - Architecture Programming And Interfacing** - Barry B. Brey [1]
+1. **The Intel Microprocessors - Architecture Programming And Interfacing** - Barry B. Brey <sup id="">[[1]](#)</sup>
 2. **Microprocessor and Interfacing** - D. V. Hall
-3. **Microprocessor Architecture, Programming, and Applications with the 8085** - Ramesh Gaonkar [5]
+3. **Microprocessor Architecture, Programming, and Applications with the 8085** - Ramesh Gaonkar <sup id="">[[5]](#)</sup>
 
 ### Alternative/Supplementary
 
@@ -475,21 +475,21 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Discrete Mathematics and Its Applications** - Kenneth H. Rosen [1]
-2. **Discrete Mathematics** - Kevin Ferland [2]
-3. **Mathematics for Computer Science** - Eric Lehman, F. Thomson Leighton, and Albert R. Meyer [3]
+1. **Discrete Mathematics and Its Applications** - Kenneth H. Rosen <sup id="">[[1]](#)</sup>
+2. **Discrete Mathematics** - Kevin Ferland <sup id="">[[2]](#)</sup>
+3. **Mathematics for Computer Science** - Eric Lehman, F. Thomson Leighton, and Albert R. Meyer <sup id="">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **Discrete and Combinatorial Mathematics: An Applied Introduction** - Ralph P. Grimaldi [4]
-2. **Discrete Mathematics for Computer Science** - Kenneth Bogart and Robert L. Drysdale [5]
-3. **Concrete Mathematics** - Ronald Graham, Donald E. Knuth and Oren Patashnik [6]
-4. **Discrete Mathematics** - Jiří Matoušek and Jaroslav Nešetřil [7]
-5. **Mathematical Structures for Computer Science** - J. L. Gersting [8]
-6. **Discrete Mathematics** - Norman L. Biggs [9]
-7. **Discrete Mathematics** - Kenneth A. Ross and Charles R. Wright [10]
-8. **Discrete Mathematics** - Seymour Lipschutz and Mar Lars Lipson [11]
-9. **Discrete Mathematics: Mathematical Reasoning and Proof with Puzzles, Patterns and Games** - Douglas E. Ensley and J. Winston Crawley [12]
+1. **Discrete and Combinatorial Mathematics: An Applied Introduction** - Ralph P. Grimaldi <sup id="">[[4]](#)</sup>
+2. **Discrete Mathematics for Computer Science** - Kenneth Bogart and Robert L. Drysdale <sup id="">[[5]](#)</sup>
+3. **Concrete Mathematics** - Ronald Graham, Donald E. Knuth and Oren Patashnik <sup id="">[[6]](#)</sup>
+4. **Discrete Mathematics** - Jiří Matoušek and Jaroslav Nešetřil <sup id="">[[7]](#)</sup>
+5. **Mathematical Structures for Computer Science** - J. L. Gersting <sup id="">[[8]](#)</sup>
+6. **Discrete Mathematics** - Norman L. Biggs <sup id="">[[9]](#)</sup>
+7. **Discrete Mathematics** - Kenneth A. Ross and Charles R. Wright <sup id="">[[10]](#)</sup>
+8. **Discrete Mathematics** - Seymour Lipschutz and Mar Lars Lipson <sup id="">[[11]](#)</sup>
+9. **Discrete Mathematics: Mathematical Reasoning and Proof with Puzzles, Patterns and Games** - Douglas E. Ensley and J. Winston Crawley <sup id="">[[12]](#)</sup>
 10. **Elements of Discrete Mathematics: A Computer Oriented Approach** - C. L. Liu and D. P. Mohapatra
 11. **Discrete Mathematical Structures with Applications, to Computer Science** - J. P. Tremblay and R. Manohar
 12. **Discrete Mathematics for Computer Scientists & Mathematics** - Joe L. Mott, A. Kandel, and T. P. Baker
@@ -523,7 +523,7 @@ Online courses about Microprocessors are rather difficult to come by.
 - [14:332:312 at Rutgers](http://eceweb1.rutgers.edu/~csi/DiscMath.html)
 - [CS 441 at PU](https://people.cs.pitt.edu/~milos/courses/cs441/)
 - [CS 70 at Berkeley](http://eecs70.org/) although notes are recommended for primary reading
-- [CS 207 at IIT Bombay](https://www.cse.iitb.ac.in/~akshayss/courses/cs207-2016.html) along with [9]
+- [CS 207 at IIT Bombay](https://www.cse.iitb.ac.in/~akshayss/courses/cs207-2016.html) along with <sup id="">[[9]](#)</sup>
 
 [3] - Used as the reference for
 
@@ -549,7 +549,7 @@ Online courses about Microprocessors are rather difficult to come by.
 
 [10] - Used as the reference for
 
-- [Discrete Mathematics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/discretemaths/) along with other recommendations like [4]
+- [Discrete Mathematics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/discretemaths/) along with other recommendations like [^](#)4
 
 [12] - Used as the reference for
 
@@ -559,21 +559,21 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Computer Graphics: Principles and Practice** - John F. Hughes, Andries van Dam, Morgan McGuire, David F. Sklar, James D. Foley, Steven K. Feiner, Kurt Akeley [1]
-2. **Fundamentals of Computer Graphics** - Pete Shirley and Steve Marschner with Michael Ashikhmin, Michael Gleicher, Naty Hoffman, Garrett Johnson, Tamara Munzner, Erik Reinhard, Kelvin Sung, William B. Thompson, Peter Willemsen, and Bryan Wyvill [2]
-3. **Computer Graphics, C Version** - Donald Hearn and M. Pauline Baker [3]
+1. **Computer Graphics: Principles and Practice** - John F. Hughes, Andries van Dam, Morgan McGuire, David F. Sklar, James D. Foley, Steven K. Feiner, Kurt Akeley <sup id="">[[1]](#)</sup>
+2. **Fundamentals of Computer Graphics** - Pete Shirley and Steve Marschner with Michael Ashikhmin, Michael Gleicher, Naty Hoffman, Garrett Johnson, Tamara Munzner, Erik Reinhard, Kelvin Sung, William B. Thompson, Peter Willemsen, and Bryan Wyvill <sup id="">[[2]](#)</sup>
+3. **Computer Graphics, C Version** - Donald Hearn and M. Pauline Baker <sup id="">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **Computer Graphics using Open GL** - Francis S. Hill [4]
-2. **Multimedia Systems** - R. Steinmetz and K. Nahrstedt [5]
-3. **Fundamentals of Multimedia** - Ze-Nian Li and M. S. Drew [6]
-4. **Mathematical Elements for Computer Graphics** - David F. Rogers and James Alan Adams [7]
-5. **Physically Based Rendering: From Theory to Implementation** - Matt Pharr and Greg Humphreys [8]
-6. **Procedural Elements for Computer Graphics** - David Rogers [9]
-7. **Computer Graphics for Java Programmers** - L. Ammeraal and K. Zhang [10]
-8. **Computer Graphics: A Survey of Current Techniques and Applications** - John Lewell [11]
-9. **Computer Graphics: Theory Into Practice** - Jeffrey J. McConnell [12]
+1. **Computer Graphics using Open GL** - Francis S. Hill <sup id="">[[4]](#)</sup>
+2. **Multimedia Systems** - R. Steinmetz and K. Nahrstedt <sup id="">[[5]](#)</sup>
+3. **Fundamentals of Multimedia** - Ze-Nian Li and M. S. Drew <sup id="">[[6]](#)</sup>
+4. **Mathematical Elements for Computer Graphics** - David F. Rogers and James Alan Adams <sup id="">[[7]](#)</sup>
+5. **Physically Based Rendering: From Theory to Implementation** - Matt Pharr and Greg Humphreys <sup id="">[[8]](#)</sup>
+6. **Procedural Elements for Computer Graphics** - David Rogers <sup id="">[[9]](#)</sup>
+7. **Computer Graphics for Java Programmers** - L. Ammeraal and K. Zhang <sup id="">[[10]](#)</sup>
+8. **Computer Graphics: A Survey of Current Techniques and Applications** - John Lewell <sup id="">[[11]](#)</sup>
+9. **Computer Graphics: Theory Into Practice** - Jeffrey J. McConnell <sup id="">[[12]](#)</sup>
 10. **Computer Graphics: Techniques and Applications** - R. D. Parslow, R. W. Prowse, Richard Elliot Green [13]
 11. **Computer graphics and virtual environments: from realism to real-time** - M. Slater, A. Steed, Y. Chrysantho [14]
 12. **Interactive environments with open-source software** - Wolfgang Höhl [15]
@@ -590,13 +590,13 @@ Online courses about Microprocessors are rather difficult to come by.
 
 - [CSCI 1230 at Brown](https://cs.brown.edu/courses/cs123/)
 - [CS4620/CS4621 at Cornell](http://www.cs.cornell.edu/courses/cs4620/2014fa/index.shtml) along with [16]
-- [CS 6360 at IITM](http://www.cse.iitm.ac.in/~vplab/computer_graphics.html) along with [3]
+- [CS 6360 at IITM](http://www.cse.iitm.ac.in/~vplab/computer_graphics.html) along with [^](#)3
 - [Introduction to Computer Graphics at UIC](https://www.cs.uic.edu/~jbell/CourseNotes/ComputerGraphics/index.html)
 - [CS 488 at UIC](https://www.evl.uic.edu/aej/488/index.html) which seems to be an earlier version of the course above
 
 [2] - Used as the reference for
 
-- [CMU 15-462/662](http://15462.courses.cs.cmu.edu/fall2015/) along with [1] and [8]
+- [CMU 15-462/662](http://15462.courses.cs.cmu.edu/fall2015/) along with [1] and <sup id="">[[8]](#)</sup>
 - [Computer Graphics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/graphics/) with [1] and others additionally recommended
 - [CS248 at Stanford](http://graphics.stanford.edu/courses/cs248-18-spring/) with [1] also recommended
 
@@ -615,8 +615,8 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Elements of Information Theory** - T. M. Cover and J. A. Thomas [1]
-2. **Information Theory, Inference and Learning Algorithms** - David J. C. Mackay [2]
+1. **Elements of Information Theory** - T. M. Cover and J. A. Thomas <sup id="">[[1]](#)</sup>
+2. **Information Theory, Inference and Learning Algorithms** - David J. C. Mackay <sup id="">[[2]](#)</sup>
 3. **Information Theory Coding and Cryptography** - R. Bose
 
 ### Alternative/Supplementary
@@ -625,9 +625,9 @@ Online courses about Microprocessors are rather difficult to come by.
 2. **Introduction to Data Compression** - Khalid Sayood
 3. **The Theory of Information and Coding** - R. J. McEliece
 4. **The Theory of Error Correcting Codes** - F. J. MacWilliams and N. J. A. Sloane
-5. **Entropy and Information Theory** - Robert M. Gray [3]
-6. **Information Theory and Reliable Communication** - R. G. Gallagher [4]
-7. **Information Theory** - Robert B. Ash [5]
+5. **Entropy and Information Theory** - Robert M. Gray <sup id="">[[3]](#)</sup>
+6. **Information Theory and Reliable Communication** - R. G. Gallagher <sup id="">[[4]](#)</sup>
+7. **Information Theory** - Robert B. Ash <sup id="">[[5]](#)</sup>
 
 ### Notes
 
@@ -663,9 +663,9 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Compilers: Principles, Techniques, and Tools** - A. V. Aho, Ravi Sethi & Jeffrey D. Ullman [1]
+1. **Compilers: Principles, Techniques, and Tools** - A. V. Aho, Ravi Sethi & Jeffrey D. Ullman <sup id="">[[1]](#)</sup>
 2. **Compiler Construction Principles and Practice** - K. C. Louden
-3. **Modern compiler implementation in ML** - A. W. Appel [2]
+3. **Modern compiler implementation in ML** - A. W. Appel <sup id="">[[2]](#)</sup>
 
 ### Alternative/Supplementary
 
@@ -689,19 +689,19 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Computer Networking: A Top-Down Approach** - James Kurose and Keith Ross [1]
-2. **Computer Networks – A System Approach** - Larry L. Peterson and Bruce S. Davie [2]
-3. **Computer Networks** - Andrew S. Tanenbaum [3]
+1. **Computer Networking: A Top-Down Approach** - James Kurose and Keith Ross <sup id="">[[1]](#)</sup>
+2. **Computer Networks – A System Approach** - Larry L. Peterson and Bruce S. Davie <sup id="">[[2]](#)</sup>
+3. **Computer Networks** - Andrew S. Tanenbaum <sup id="">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
 1. **TCP/IP protocol Suite** - Behrouz A. Forouzan
-2. **Data and Computer Communication** - William Stallings [4]
+2. **Data and Computer Communication** - William Stallings <sup id="">[[4]](#)</sup>
 3. **Data Communication, Computer Networks and Open Systems** - F. Halsall
-4. **Data Communications and Networking** - Behrouz A. Forouzan [5]
+4. **Data Communications and Networking** - Behrouz A. Forouzan <sup id="">[[5]](#)</sup>
 5. **Internetworking with TCP/IP, Volume 1** - Douglas Comer
-6. **TCP/IP Illustrated, Volume 1: The Protocols** - W. Richard Stevens [6]
-7. **Unix Network Programming, Volume 1: The Sockets Networking API** - W. Richard Stevens [7]
+6. **TCP/IP Illustrated, Volume 1: The Protocols** - W. Richard Stevens <sup id="">[[6]](#)</sup>
+7. **Unix Network Programming, Volume 1: The Sockets Networking API** - W. Richard Stevens <sup id="">[[7]](#)</sup>
 
 ### Notes
 
@@ -711,13 +711,13 @@ Online courses about Microprocessors are rather difficult to come by.
 
 - [CS60 at Dartmouth](http://www.cs.dartmouth.edu/~campbell/cs60/) where texts on Shell Scripting like **A Practical Guide to Linux Commands, Editors, and Shell Programming** by Mark G. Sobell are also recommended
 - [CS 356 at UT Austin](http://www.cs.utexas.edu/users/lam/cs356/)
-- [COS 461 at Princeton](https://www.cs.princeton.edu/courses/archive/spring17/cos461/) along with [2]
+- [COS 461 at Princeton](https://www.cs.princeton.edu/courses/archive/spring17/cos461/) along with [^](#)2
 - [CS244A at Stanford](http://web.stanford.edu/class/cs244a/)
 
 [2] - Used as the reference for
 
 - [15-441 at CMU](https://www.cs.cmu.edu/~prs/15-441-F16/)
-- [Computer Networks at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/networks/) along with [3]
+- [Computer Networks at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/networks/) along with <sup id="">[[3]](#)</sup>
 - [CS 640 at UWISC](http://pages.cs.wisc.edu/~pb/cs640.html)
 
 [4] - Used as the reference for
@@ -732,12 +732,12 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Software Engineering A Practitioner’s Approach** - Roger S. Pressman [1]
-2. **Software Engineering** - Ian Sommerville [2]
+1. **Software Engineering A Practitioner’s Approach** - Roger S. Pressman <sup id="">[[1]](#)</sup>
+2. **Software Engineering** - Ian Sommerville <sup id="">[[2]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **An Integrated Approach to Software Engineering** - Pankaj Jalote [3]
+1. **An Integrated Approach to Software Engineering** - Pankaj Jalote <sup id="">[[3]](#)</sup>
 2. **Software Engineering Fundamentals** - A. Behferooz and F. J. Hudson
 3. **Fundamentals of Software Engineering** - Rajib Mall
 4. **Software Engineering** - Gaurav Gupta and Deepika Gupta
@@ -745,13 +745,13 @@ Online courses about Microprocessors are rather difficult to come by.
 6. **Software Engineering 1st Edition** - Udit Agarwal
 7. **Algebraic Methodology and Software Technology** - Grigore Rosu and Jose Meseguer
 8. **Software Design Methodology: From Principles to Architectural Styles** - Hong Zhu
-9. **Object-oriented Software Engineering : using UML, patterns, and Java** - Bernd Bruegge and Allen Dutoit [4]
-10. **The New Software Engineering** - Sue A. Conger [5]
-11. **The Pragmatic Programmer** - Dave Thomas and Andy Hunt [6]
-12. **Software Engineering** - Ivan Marsic [7]
-13. **Design Patterns:  Elements of Reusable Object-Oriented Software**-  E. Gamma, R. Helm, R. Johnson, and J. Vlissides [8]
-14. **Object-Oriented Software Engineering: Practical Software Development using UML and Java** - Timothy C. Lethbridge and Robert Laganière [9]
-15. **Fundamentals of Software Engineering** - Carlo Ghezzi [10]
+9. **Object-oriented Software Engineering : using UML, patterns, and Java** - Bernd Bruegge and Allen Dutoit <sup id="">[[4]](#)</sup>
+10. **The New Software Engineering** - Sue A. Conger <sup id="">[[5]](#)</sup>
+11. **The Pragmatic Programmer** - Dave Thomas and Andy Hunt <sup id="">[[6]](#)</sup>
+12. **Software Engineering** - Ivan Marsic <sup id="">[[7]](#)</sup>
+13. **Design Patterns:  Elements of Reusable Object-Oriented Software**-  E. Gamma, R. Helm, R. Johnson, and J. Vlissides <sup id="">[[8]](#)</sup>
+14. **Object-Oriented Software Engineering: Practical Software Development using UML and Java** - Timothy C. Lethbridge and Robert Laganière <sup id="">[[9]](#)</sup>
+15. **Fundamentals of Software Engineering** - Carlo Ghezzi <sup id="">[[10]](#)</sup>
 
 ### Notes
 

--- a/Curriculum.md
+++ b/Curriculum.md
@@ -86,19 +86,19 @@
 
 ### Standard Textbooks
 
-1. **Database Management Systems** - Johannes Gehrke and Raghu Ramakrishnan <sup id="">[[1]](#)</sup>
-2. **Database System Concepts** - Abraham Silberschatz, Henry F. Korth & S. Sudarshan <sup id="">[[2]](#)</sup>
-3. **Readings in Database Systems** - Joseph M. Hellerstein and Michael Stonebraker (*The (Databases) Red Book*) <sup id="">[[3]](#)</sup>
+1. **Database Management Systems** - Johannes Gehrke and Raghu Ramakrishnan <sup id="DMSref">[[1]](#DMS)</sup>
+2. **Database System Concepts** - Abraham Silberschatz, Henry F. Korth & S. Sudarshan <sup id="DSCref">[[2]](#DSC)</sup>
+3. **Readings in Database Systems** - Joseph M. Hellerstein and Michael Stonebraker (*The (Databases) Red Book*) <sup id="TDRBref">[[3]](#TDRB)</sup>
 
 ### Alternative/Supplementary
 
 1. **Principles of Database Systems** - Jeffrey D. Ullman
-2. **An Introduction to Database system** - B. Desai
+2. **An Introduction to Database System** - B. Desai
 3. **An Introduction to Database Systems** - Christopher J. Date
 4. **Fundamentals of Database Systems** - R. Elmasri, S. Navathe, S. B. Navathe, R. Sunderraman
-5. **Database Systems: The Complete Book** - Hector Garcia-Molina, Jeffrey D. Ullman and Jennifer Widom <sup id="">[[4]](#)</sup>
+5. **Database Systems: The Complete Book** - Hector Garcia-Molina, Jeffrey D. Ullman and Jennifer Widom <sup id="DSCBref">[[4]](#DSCB)</sup>
 6. **Transaction Processing: Concepts and Techniques** - Jim Gray and Andreas Reuter
-7. **A First Course in Database Systems** - Jeffrey Ullman and Jennifer Widom <sup id="">[[5]](#)</sup>
+7. **A First Course in Database Systems** - Jeffrey Ullman and Jennifer Widom <sup id="FCDSref">[[5]](#FCDS)</sup>
 8. **Database Systems** - Carolyn E. Begg and Thomas M. Connolly
 9. **Database Concepts** - David M. Kroenke and David J. Auer
 10. **Physical Database Design: the database professional's guide to exploitingindexes, views, storage, and more** - T. Teorey, S. Lightstone and T. Nadeau
@@ -109,7 +109,7 @@
 - This is a rather modern theoretical topic which is the backbone of many systems we commonly use. Database books are also not available in as much variety as the other topics.
 - [*TYCS*](https://teachyourselfcs.com/#databases) recommends going through [video lectures from Berkeley](https://archive.org/details/UCBerkeley_Course_Computer_Science_186) before textbooks.
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="DMS" href="#DMSref">^</a>1 - Used as the reference for
 
 - [CS 186 at Berkeley](http://www.cs186berkeley.net/home)
 - [CS 4320/4321 at Cornell](http://www.cs.cornell.edu/courses/cs4320/2008fa/)
@@ -122,43 +122,43 @@
 - [CS/SE 4347 at UT Dallas](https://www.utdallas.edu/~muratk/courses/undb07.html)
 - [CS662 at UoV](http://www.cs.virginia.edu/~son/cs662.s06/)
 
-<a id="" href="#">^</a>2 - Used as the reference for
+<a id="DSC" href="#DSCref">^</a>2 - Used as the reference for
 
 - [CS 23500/33550 at UoC](https://www.classes.cs.uchicago.edu/archive/2017/winter/23500-1/syllabus.html) (Note: Syllabus page only)
 - [15-445/645 at CMU](https://15445.courses.cs.cmu.edu/fall2017/)
-- [CS 348 at UoW](https://cs.uwaterloo.ca/~david/cs348/) along with [^](#)1
+- [CS 348 at UoW](https://cs.uwaterloo.ca/~david/cs348/) along with [^](#DMS)1
 
-<a id="" href="#">^</a>3 - It is the recommended book on [*TYCS*](https://teachyourselfcs.com/#databases). Used as the reference for
+<a id="TDRB" href="#TDRBref">^</a>3 - It is the recommended book on [*TYCS*](https://teachyourselfcs.com/#databases). Used as the reference for
 
 - [ECS 165A at UC Davis](http://web.cs.ucdavis.edu/~green/courses/ecs165a-w11/)
 
-<a id="" href="#">^</a>4 - Used as the reference for
+<a id="DSCB" href="#DSCBref">^</a>4 - Used as the reference for
 
 - [CS145 at Stanford](http://web.stanford.edu/class/cs145/)
 
-<a id="" href="#">^</a>5 - Used as the reference for
+<a id="FCDS" href="#FCDSref">^</a>5 - Used as the reference for
 
-- [CS x265 at VU](https://my.vanderbilt.edu/cs265/) but strongly recommends going through **Jennifer Widom's** self paced "Databases Course" on [Stanford Lagunita](https://lagunita.stanford.edu/courses/DB/2014/SelfPaced/about)
+- [CS x265 at VU](https://my.vanderbilt.edu/cs265/) but strongly recommends going through **Jennifer Widom's** self paced ["**Databases Course**" on Stanford Lagunita](https://lagunita.stanford.edu/courses/DB/2014/SelfPaced/about)
 
 ## Principles of Programming Languages
 
 ### Standard Textbooks
 
-1. **Essentials of Programming Languages** - Daniel P. Friedman, Mitchell Wand and Christopher T. Haynes (*EOPL*) <sup id="">[[1]](#)</sup>
-2. **Concepts in Programming Languages** - John C. Mitchell <sup id="">[[2]](#)</sup>
-3. **Programming Languages: Application and Interpretation** - S. Krishnamurthi (*PLAI*) <sup id="">[[3]](#)</sup>
+1. **Essentials of Programming Languages** - Daniel P. Friedman, Mitchell Wand and Christopher T. Haynes (*EOPL*) <sup id="EOPLref">[[1]](#EOPL)</sup>
+2. **Concepts in Programming Languages** - John C. Mitchell <sup id="CPLref">[[2]](#CPLref)</sup>
+3. **Programming Languages: Application and Interpretation** - S. Krishnamurthi (*PLAI*) <sup id="PLAIref">[[3]](#PLAI)</sup>
 
 ### Alternative/Supplementary
 
-1. **Programming Language Pragmatics** - Michael L. Scott <sup id="">[[4]](#)</sup>
-2. **Types and Programming Languages** - Benjamin C. Pierce (*TAPL*) <sup id="">[[5]](#)</sup>
-3. **A Formal Semantics of Programming Languages: An Introduction** - Glynn Winskel <sup id="">[[6]](#)</sup>
-4. **Structure and Interpretation of Computer Programs** -	Harold Abelson, Gerald Jay Sussman and Julie Sussman (*SICP*) <sup id="">[[7]](#)</sup>
-5. **Concepts of Programming Languages** - Robert W. Sebesta <sup id="">[[8]](#)</sup>
-6. **Practical Foundations of Programming Languages** - Robert Harper <sup id="">[[9]](#)</sup>
-7. **Programming Languages: Design and Implementation** - T. W. Prat & M. V. Zelkowitz <sup id="">[[10]](#)</sup>
-8. **Programming Languages: Principles & Practices** - Kenneth C. Louden <sup id="">[[11]](#)</sup>
-9. **Programming Languages: Principles and Paradigms** - Maurizio Gabbrielli and Simone Martini <sup id="">[[12]](#)</sup>
+1. **Programming Language Pragmatics** - Michael L. Scott <sup id="PLPref">[[4]](#PLP)</sup>
+2. **Types and Programming Languages** - Benjamin C. Pierce (*TAPL*) <sup id="TAPLref">[[5]](#TAPL)</sup>
+3. **A Formal Semantics of Programming Languages: An Introduction** - Glynn Winskel <sup id="FSPLref">[[6]](#FSPL)</sup>
+4. **Structure and Interpretation of Computer Programs** -	Harold Abelson, Gerald Jay Sussman and Julie Sussman (*SICP*) <sup id="SICPref">[[7]](#SICP)</sup>
+5. **Concepts of Programming Languages** - Robert W. Sebesta <sup id="COPLref">[[8]](#COPL)</sup>
+6. **Practical Foundations of Programming Languages** - Robert Harper <sup id="PLPLref">[[9]](#PLPL)</sup>
+7. **Programming Languages: Design and Implementation** - T. W. Prat & M. V. Zelkowitz <sup id="PLDIref">[[10]](#PLDI)</sup>
+8. **Programming Languages: Principles & Practices** - Kenneth C. Louden <sup id="PLPPRref">[[11]](#PLPPR)</sup>
+9. **Programming Languages: Principles and Paradigms** - Maurizio Gabbrielli and Simone Martini <sup id="PLPPAref">[[12]](#PLPPA)</sup>
 10. **Programming Languages – Concepts & Constructs** - Ravi Sethi
 11. **Foundations for Programming Languages** - John C. Mitchell
 12. **The Lambda Calculus: Its Syntax and Semantics** - H. P. Barendregt
@@ -167,7 +167,7 @@
 15. **Design Concepts in Programming Languages** - Franklyn Turbak and David Gifford
 16. **Concepts, Techniques and Models of Computer Programming** - Peter Van Roy and Seif Haridi
 17. **Paradigms of Artificial Intelligence Programming: Case Studies in Common Lisp** - Peter Norvig
-18. **Theories of Programming Languages** - John C. Reynolds [13]
+18. **Theories of Programming Languages** - John C. Reynolds <sup id="TOPLref">[[13]](#TOPL)</sup>
 19. **Type Theory and Functional Programming** - Simon Thompson
 
 ### Notes
@@ -175,50 +175,50 @@
 - **Benjamin Pierce** has a [**list of Great Works in Programming Languages**](https://www.cis.upenn.edu/~bcpierce/courses/670Fall04/GreatWorksInPL.shtml).
 - [CSE526 at SUNY, SB](https://bsd7.cs.stonybrook.edu/~cse526/) has a list of readings from different books and papers in addition to the lecture notes.
 - [Principles of Programming Langugages at DEIB-P](https://home.deib.polimi.it/pradella/PL.html) has a list of readings from every language and has a list of papers to go through. There is no recommended textbook from the list above.
-- [CS 152 at Harvard](https://www.seas.harvard.edu/courses/cs152/2018sp/index.html) uses notes for their readings but also recommends [2], [5], [6] and [3] for additional reference.
-- [CS 6110 at Cornell](https://www.cs.cornell.edu/courses/cs6110/2018sp/index.html) has no required textbook but recommends [6] and [5] for additional reading.
-- A [free version](https://www.cs.cmu.edu/~jcr/tpl.html) of [13] is available for reading. I was unable to find any related course material.
+- [CS 152 at Harvard](https://www.seas.harvard.edu/courses/cs152/2018sp/index.html) uses notes for their readings but also recommends [^](#CPLref)2, [^](#TAPLref)5, [^](#FSPLref)6 and [^](#PLAIref)3 for additional reference.
+- [CS 6110 at Cornell](https://www.cs.cornell.edu/courses/cs6110/2018sp/index.html) has no required textbook but recommends [^](#FSPLref)6 and [^](#TAPLref)5 for additional reading.
+- A [free version](https://www.cs.cmu.edu/~jcr/tpl.html) of [^](#TOPLref)13 is available for reading. I was unable to find any related course material.
 - [601.426/626 at JHU](http://pl.cs.jhu.edu/pl/index.shtml) use their own book created by a course instructor. The book itself is available under Creative Commons License [here](http://pl.cs.jhu.edu/pl/book/book.pdf).
 - An extensive list of resources can also be found at [Programming Language Theory](http://steshaw.org/plt/).
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="EOPL" href="#EOPLref">^</a>1 - Used as the reference for
 
-- [CS 6848 at IIT, Madras](https://www.cse.iitm.ac.in/~krishna/courses/2015/odd-cs6848/) along with [5], with [2] and [9] for additional reference
+- [CS 6848 at IIT, Madras](https://www.cse.iitm.ac.in/~krishna/courses/2015/odd-cs6848/) along with [^](#TAPLref)5, with [^](#CPLref)2 and [^](#PLPLref)9 for additional reference
 - [Principles of Programming Languages at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/principles/)
 - [CS G111 at NEU](https://course.ccs.neu.edu/csg111/)
 - [CSCI-UA.0480-006](https://cs.nyu.edu/wies/teaching/popl-15/) and has a host of other useful links
 - [CS704 at UWISC](https://github.com/barghouthi/cs704) and has a number of other recommendations as well
 - [CSCI 3155 at Berkeley](http://csci3155.cs.colorado.edu/s18/) but the recommended readings are from notes with a bunch of other resources linked
 
-<a id="" href="#">^</a>2 - Please make sure to go through the [errata listed](http://theory.stanford.edu/people/jcm/books/cpl-errata.html) when using this book. Used as the reference for
+<a id="CPL" href="#CPLref">^</a>2 - Please make sure to go through the [errata listed](http://theory.stanford.edu/people/jcm/books/cpl-errata.html) when using this book. Used as the reference for
 
-- [CS 59 at Dartmouth](http://www.cs.dartmouth.edu/~sergey/cs59/syllabus.pdf) is a syllabus only page with many other materials on the instructor's website and also uses some material from <sup id="">[[7]](#)</sup>
+- [CS 59 at Dartmouth](http://www.cs.dartmouth.edu/~sergey/cs59/syllabus.pdf) is a syllabus only page with many other materials on the instructor's website and also uses some material from [^](#SICPref)7
 - [CSCI 334 at WC](http://www.cs.williams.edu/~dbarowy/cs334s18/)
 
-<a id="" href="#">^</a>4 - Used as the reference for
+<a id="PLP" href="#PLPref">^</a>4 - Used as the reference for
 
 - [CS 245 at BMC](https://cs.brynmawr.edu/Courses/cs245/fall2010/)
 - [CSc 520 at UAT](https://www2.cs.arizona.edu/classes/cs520/spring06/)
-- [CSCI 3136 at Dal](https://web.cs.dal.ca/~nzeh/Teaching/3136/index.html) which also recommends reading [7], [2], [10] and **The Cinderella Book**
+- [CSCI 3136 at Dal](https://web.cs.dal.ca/~nzeh/Teaching/3136/index.html) which also recommends reading [^](#SICPref)7, [^](#CPLref)2, [^](#PLDIref)10 and [^](#TCBref)**The Cinderella Book**
 
-<a id="" href="#">^</a>6 - Used as the reference for
+<a id="FSPL" href="#FSPLref">^</a>6 - Used as the reference for
 
 - [COMP 411 at RU](https://www.cs.rice.edu/~javaplt/411/14-spring/)
 
-<a id="" href="#">^</a>8 - Used as the reference for
+<a id="COPL" href="#COPLref">^</a>8 - Used as the reference for
 
 - [CSC 272 at AU](https://home.adelphi.edu/~siegfried/cs272/)
 - [CS 3MI3 at MMU](http://www.cas.mcmaster.ca/~franek/courses/cs3mi3/)
 
-<a id="" href="#">^</a>9 - Used as the reference for
+<a id="PLPL" href="#PLPLref">^</a>9 - Used as the reference for
 
 - [15-312 at CMU](https://www.cs.cmu.edu/~jcr/tpl.html)
 
-<a id="" href="#">^</a>11 - Used as the reference for
+<a id="PLPPR" href="#PLPPRref">^</a>11 - Used as the reference for
 
 - [CMSC 245 at HC](https://www.haverford.edu/computer-science/course-pages/2016f-cmsc-245-principles-programming-languages) (Note: Syllabus page only)
 
-<a id="" href="#">^</a>12 - Used as the reference for
+<a id="PLPPA" href="#PLPPAref">^</a>12 - Used as the reference for
 
 - [TIE-20306 at TUT](http://www.cs.tut.fi/~popl/nykyinen/index.shtml) along with a free *Finnish* textbook
 
@@ -226,52 +226,52 @@
 
 ### Standard Textbooks
 
-1. **Computer Architecture: A Quantitative Approach** - David A. Patterson and John L. Hennessy <sup id="">[[1]](#)</sup>
-2. **Computer Organisation and Design: The Hardware/Software Interface** - David A. Patterson and John L. Hennessy <sup id="">[[2]](#)</sup>
-3. **Computer Organisation** - V. C. Hamacher, Zvonko G. Vranesic and Safwat G. Zaky <sup id="">[[3]](#)</sup>
+1. **Computer Architecture: A Quantitative Approach** - David A. Patterson and John L. Hennessy <sup id="CAHPref">[[1]](#CAHP)</sup>
+2. **Computer Organisation and Design: The Hardware/Software Interface** - David A. Patterson and John L. Hennessy <sup id="CODHP">[[2]](#CODHP)</sup>
+3. **Computer Organisation** - V. C. Hamacher, Zvonko G. Vranesic and Safwat G. Zaky <sup id="CO">[[3]](#CO)</sup>
 
 ### Alternative/Supplementary
 
-1. **Computer System Architecture** - M. Morris Mano <sup id="">[[4]](#)</sup>
-2. **Computer Organization and Architecture: Designing for Performance** - William Stallings <sup id="">[[5]](#)</sup>
-3. **Computer Architecture and Organisation** - John. P. Hayes <sup id="">[[6]](#)</sup>
+1. **Computer System Architecture** - M. Morris Mano <sup id="CSAref">[[4]](#CSA)</sup>
+2. **Computer Organization and Architecture: Designing for Performance** - William Stallings <sup id="COADPref">[[5]](#COADP)</sup>
+3. **Computer Architecture and Organisation** - John. P. Hayes <sup id="COAref">[[6]](#COA)</sup>
 4. **Computer Systems Design and Architecture** - Vincent P Heuring and Harry F Jordan
 5. **Fundamentals of Computer Organization and Architecture** - Mostafa Abd-El-Barr and Hesham El-Rewini
-6. **Computer Systems: a Programmer’s Perspective** - Randal E. Bryant and David R. O’Hallaron <sup id="">[[7]](#)</sup>
-7. **Introduction to Computing Systems: From Bits and Gates to C and Beyond** - Patt and Patel <sup id="">[[8]](#)</sup>
+6. **Computer Systems: a Programmer’s Perspective** - Randal E. Bryant and David R. O’Hallaron <sup id="CSPPref">[[7]](#CSPP)</sup>
+7. **Introduction to Computing Systems: From Bits and Gates to C and Beyond** - Patt and Patel <sup id="ITCPref">[[8]](#ITCP)</sup>
 8. **Structured Computer Organization** - Andrew S. Tanenbaum
 9. **The Principles of Computer Hardware** - A. Clements
 10. **Fundamentals of Computer Architecture** - M. Burrell
-11. **Computer Architecture: Pipelined and Parallel Processor Design** - Michael J. Flynn <sup id="">[[9]](#)</sup>
+11. **Computer Architecture: Pipelined and Parallel Processor Design** - Michael J. Flynn <sup id="CAPPDref">[[9]](#CAPPD)</sup>
 
 ### Notes
 
 There are plenty more books than listed and more courses than I'd care to link.
 
-<a id="" href="#">^</a>1 - Widely regarded as an authoritative reference for Computer Organisation and Architecture. It is written by Turing Award winning Computer Scientists David Patterson and John Hennessy, but also assumes the reader is already well versed with concepts of Computer Architecture. For the beginner, [2] is widely recommended as _the_ book to start with. Used as a reference for
+<a id="CAHP" href="#CAHPref">^</a>1 - Widely regarded as an authoritative reference for Computer Organisation and Architecture. It is written by Turing Award winning Computer Scientists David Patterson and John Hennessy, but also assumes the reader is already well versed with concepts of Computer Architecture. For the beginner, [^](#CODHref)2 is widely recommended as _the_ book to start with. Used as a reference for
 
 - [CS146 at Harvard](http://www.eecs.harvard.edu/~dbrooks/cs146-spring2004/)
 
-<a id="" href="#">^</a>2 - [TYCS](https://teachyourselfcs.com/#architecture) recommends this excellent book (after going through **The Elements of Computing Systems** by Nishan and Schocken), as do I, for an introduction to the fundamental ideas of Computer Organisation and Architecture. It is extremely well written, has plenty of depth, and is built upon in [1] by the same authors. Used as a reference for
+<a id="CODHP" href="#CODHPref">^</a>2 - [TYCS](https://teachyourselfcs.com/#architecture) recommends this excellent book (after going through **The Elements of Computing Systems** by Nishan and Schocken) for an introduction to the fundamental ideas of Computer Organisation and Architecture. It is extremely well written, has plenty of depth, and is built upon in [^](#CAHPref)1 by the same authors. Used as a reference for
 
 - [CS 312 at UMSL](http://www.cs.umsl.edu/~sanjiv/classes/cs312/)
 - [ECE 411 at UI](https://ece.illinois.edu/academics/courses/profile/ECE411)
 - [B62006Y-01 at ](http://english.ucas.ac.cn/index.php/admission/undergraduate/course-syllabuses/620-school-of-computer-and-control-engineering/4471-principles-of-computer-organization) (Note: Syllabus page only)
-- [18-447 at CMU](http://www.ece.cmu.edu/~ece447/s13/doku.php?id=schedule) along with <sup id="">[[8]](#)</sup>
+- [18-447 at CMU](http://www.ece.cmu.edu/~ece447/s13/doku.php?id=schedule) along with [^](#ITCPref)8
 - [CS 3410 at Cornell](http://www.cs.cornell.edu/courses/cs3410/2016fa/)
 - [CS 61C at Berkeley](http://www-inst.eecs.berkeley.edu/%7Ecs61c/sp15/#Resources)
 
-<a id="" href="#">^</a>4 - I didn't find this book stimulating at all.
+<a id="CSA" href="#CSAref">^</a>4 - I didn't find this book stimulating at all.
 
-<a id="" href="#">^</a>6 - I found this book incredibly dull and difficult to understand. Good luck.
+<a id="COA" href="#COAref">^</a>6 - I found this book incredibly dull and difficult to understand. Good luck.
 
-[7] - Used as the reference for
+<a id="CSPP" href="#CSPPref">^</a>7 - Used as the reference for
 
 - [CS 2505 at VT](http://courses.cs.vt.edu/~cs2505/spring2018/)
 - [15-213/18-213 at CMU](http://www.cs.cmu.edu/%7E213/)
 - [CS107 at Stanford](http://web.stanford.edu/class/cs107/)
 
-<a id="" href="#">^</a>9 - Used as the reference for
+<a id="CAPPD" href="#CAPPDref">^</a>9 - Used as the reference for
 
 - [EE382 at Stanford](https://web.stanford.edu/class/ee382/)
 
@@ -279,15 +279,15 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Standard Textbooks
 
-1. **Introduction to Algorithms** - Thomas Cormen, C. Leiserson, and R. Rivest and C. Stein (*CLRS*) <sup id="">[[1]](#)</sup>
-2. **Algorithm Design** - Jon Kleinberg and Éva Tardos (*KT*) <sup id="">[[2]](#)</sup>
-3. **Algorithms** - Christos Papadimitriou, Sanjoy Dasgupta, and Umesh Vazirani (*DPV*) <sup id="">[[3]](#)</sup>
+1. **Introduction to Algorithms** - Thomas Cormen, C. Leiserson, and R. Rivest and C. Stein (*CLRS*) <sup id="ref">[[1]](#)</sup>
+2. **Algorithm Design** - Jon Kleinberg and Éva Tardos (*KT*) <sup id="ref">[[2]](#)</sup>
+3. **Algorithms** - Christos Papadimitriou, Sanjoy Dasgupta, and Umesh Vazirani (*DPV*) <sup id="ref">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **The Algorithm Design Manual** - Steven Skiena <sup id="">[[4]](#)</sup>
-2. **Algorithms** - Robert Sedgewick and Kevin Wayne <sup id="">[[5]](#)</sup>
-3. **Introduction to Algorithms: A Creative Approach** - Udi Manber <sup id="">[[6]](#)</sup>
+1. **The Algorithm Design Manual** - Steven Skiena <sup id="ref">[[4]](#)</sup>
+2. **Algorithms** - Robert Sedgewick and Kevin Wayne <sup id="ref">[[5]](#)</sup>
+3. **Introduction to Algorithms: A Creative Approach** - Udi Manber <sup id="ref">[[6]](#)</sup>
 4. **Fundamentals of Computer Algorithms** - Ellis Horowitz, Sartaj Sahni and S. Rajasekaran
 5. **An Introduction to the Analysis of Algorithms** - Robert Sedgewick and Philippe Flajolet
 6. **Design and Analysis of Algorithm** - P. H. Dave and H. B. Dave
@@ -305,13 +305,13 @@ There are plenty more books than listed and more courses than I'd care to link.
 - [Algorithms, Etc. by Jeff Erickson](http://jeffe.cs.illinois.edu/teaching/algorithms/) is a set of notes that covers the material necessary for his course at University of Illinois.
 - *TAOCP* also serves as a useful reference for many algorithms typically studied as part of an undergraduate level course. It is quite mathematical so typically many students find it a hard read.
 
-<a id="" href="#">^</a>1 - Typically used as an encyclopedic reference for most topic, rather than an introduction to algorithms. Used as the reference for
+<a id="" href="#ref">^</a>1 - Typically used as an encyclopedic reference for most topic, rather than an introduction to algorithms. Used as the reference for
 
 - [CS 600 A at SIT](https://www.cs.stevens.edu/~swetzel/CS600/spring11/)
 - [15-451/651 at CMU](https://www.cs.cmu.edu/~15451/) which also recommends [3] but either can be used, while an [older version](http://www.cs.cmu.edu/~avrim/451f09/index.html) has it's own set of notes
 - [CS 466/666 at UoW](https://cs.uwaterloo.ca/~eblais/courses/F17/CS466/) with additional material described [here](https://cs.uwaterloo.ca/~eblais/courses/F17/CS466/outline.pdf)
 
-<a id="" href="#">^</a>2 - Used as the reference for
+<a id="" href="#ref">^</a>2 - Used as the reference for
 
 - [CSci 256 at WC](https://www.cs.williams.edu/~lenhart/cs256/index.html)
 - [CPSC500 at UBC](http://www.cs.ubc.ca/~condon/cpsc500/) with [3] additionally recommended along with other texts
@@ -319,15 +319,15 @@ There are plenty more books than listed and more courses than I'd care to link.
 - [CS 161 at Stanford](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms) where Tim has made his lecture videos available to all
 - [CS 7820 at Cornell](http://www.cs.cornell.edu/courses/cs6820/2009fa/) taken by **Jon Kleinberg**
 
-<a id="" href="#">^</a>3 - Used as the reference for
+<a id="" href="#ref">^</a>3 - Used as the reference for
 
 - [CS 157 at Brown](https://cs.brown.edu/courses/cs157/)
 
-<a id="" href="#">^</a>4 - Recommended by *TYCS*. Used as the reference for
+<a id="" href="#ref">^</a>4 - Recommended by *TYCS*. Used as the reference for
 
 - [CSE 373 at SUNY, SB](http://www3.cs.stonybrook.edu/~skiena/373/) which is taken by **Steven Skiena**
 
-<a id="" href="#">^</a>5 - Used as the reference for
+<a id="" href="#ref">^</a>5 - Used as the reference for
 
 - [COS226 at Princeton](http://www.cs.princeton.edu/courses/archive/spring18/cos226/) with a [condensed version of the book](https://algs4.cs.princeton.edu/home/) available for reference
 
@@ -335,13 +335,13 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Standard Textbooks
 
-1. **Introduction to Automata Theory, Languages, and Computation** - John E. Hopcroft and Jeffrey D. Ullman (_The Cinderella Book_) <sup id="">[[1]](#)</sup>
-2. **Introduction to the Theory of Computation** - Michael Sipser <sup id="">[[2]](#)</sup>
+1. **Introduction to Automata Theory, Languages, and Computation** - John E. Hopcroft and Jeffrey D. Ullman (_The Cinderella Book_) <sup id="TCBref">[[1]](#TCB)</sup>
+2. **Introduction to the Theory of Computation** - Michael Sipser <sup id="ref">[[2]](#)</sup>
 3. **Elements of the Theory of Computation** - Harry R. Lewis & C. H. Papadimitriou
 
 ### Alternative/Supplementary
 
-1. **Introduction to Formal Language and Computation** - Peter Linz <sup id="">[[4]](#)</sup>
+1. **Introduction to Formal Language and Computation** - Peter Linz <sup id="ref">[[4]](#)</sup>
 2. **Theory of Computer Science: Automata, Language and Computation** - Mishra & Chandrasekharan
 3. **A Text Book on Automata Theory** - Nasir & Sirmani
 4. **Introduction to Languages and The Theory of Computation** - John Martin
@@ -354,20 +354,20 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Notes
 
-<a id="" href="#">^</a>1 - Used a reference textbook for many courses around the world. It closely matches what Jeff Ullman [teaches online at Lagunita](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about). (Duh)
+<a id="" href="#ref">^</a>1 - Used a reference textbook for many courses around the world. It closely matches what Jeff Ullman [teaches online at Lagunita](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about). (Duh)
 
-<a id="" href="#">^</a>2 - Used as the reference for
+<a id="" href="#ref">^</a>2 - Used as the reference for
 
 - [CS 3102 at UoV](http://www.cs.virginia.edu/~robins/cs3102/)
 - [CS-251 at EPFL](http://theory.epfl.ch/cs251/Home.html)
 - [CS 3800 at NEU](https://course.ccs.neu.edu/cs3800f17wc/policies.html)
 - [CS39 at Dartmouth](https://www.cs.dartmouth.edu/~ac/Teach/CS39-Spring18/)
 
-<a id="" href="#">^</a>4 - Used as the reference for
+<a id="" href="#ref">^</a>4 - Used as the reference for
 
 - [UPenn's CSC 4170-50](https://www.seas.upenn.edu/~cit596/notes/dave/syllabus.html)
 
-<a id="" href="#">^</a>5 - Used as the reference for
+<a id="" href="#ref">^</a>5 - Used as the reference for
 
 - [AU's COMP 674](http://www.athabascau.ca/syllabi/comp/comp674.php), a graduate level course.
 
@@ -375,26 +375,26 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Standard Textbooks
 
-1. **Operating System Concepts** - J. L. Peterson and A. Silberschatz (*The Dinosaur Book*) <sup id="">[[1]](#)</sup>
+1. **Operating System Concepts** - J. L. Peterson and A. Silberschatz (*The Dinosaur Book*) <sup id="ref">[[1]](#)</sup>
 2. **Modern Operating Systems** - Andrew S. Tanenbaum
-3. **Operating Systems, Internals and Design Principles** - William Stallings <sup id="">[[2]](#)</sup>
+3. **Operating Systems, Internals and Design Principles** - William Stallings <sup id="ref">[[2]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **Operating Systems: Three Easy Pieces** - Remzi H. Arpaci-Dusseau and Andrea C. Arpaci-Dusseau (*The Black Book*/*The Asteroid Book*/*The Comet Book*) <sup id="">[[3]](#)</sup>
+1. **Operating Systems: Three Easy Pieces** - Remzi H. Arpaci-Dusseau and Andrea C. Arpaci-Dusseau (*The Black Book*/*The Asteroid Book*/*The Comet Book*) <sup id="ref">[[3]](#)</sup>
 2. **Schaum’s Outline of Operating Systems** - Archer J. Harris
 3. **The Design of the UNIX operating system** - Maurice J. Bach
-4. **Operating Systems: Principles and Practice** - Thomas Anderson and Michael Dahlin. <sup id="">[[4]](#)</sup>
+4. **Operating Systems: Principles and Practice** - Thomas Anderson and Michael Dahlin. <sup id="ref">[[4]](#)</sup>
 5. **Operating Systems: A Concept-Based Approach** - D. M. Dhamdhere
 6. **Operating Systems: A Modern Perspective** - Gary J. Nutt
-7. **Operating Systems In Depth: Design and Programming** - Thomas W. Doeppner <sup id="">[[5]](#)</sup>
-8. **Operating System Concepts Essentials** - Silberschatz, Galvin, Gagne <sup id="">[[6]](#)</sup>
+7. **Operating Systems In Depth: Design and Programming** - Thomas W. Doeppner <sup id="ref">[[5]](#)</sup>
+8. **Operating System Concepts Essentials** - Silberschatz, Galvin, Gagne <sup id="ref">[[6]](#)</sup>
 
 ### Notes
 
 For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Operating_systems) provides a list of a series of breakthroughs in Operating System Design. [A list of research papers on Udacity](https://www.udacity.com/wiki/ud156-readings) may also be useful, and are the recommended readings for [CS 6210 at GATech](https://www.omscs.gatech.edu/cs-6210-advanced-operating-systems).
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="" href="#ref">^</a>1 - Used as the reference for
 
 - [CS 385 at UIC](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems/)
 - [CM's 15-410](https://www.cs.cmu.edu/~410/)
@@ -402,23 +402,23 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 - [Drexel's CS 543](https://www.cs.drexel.edu/~jjohnson/2012-13/fall/cs543/) which again recommends reading **Linux Kernel Development**.
 - [CS170 at UCSB](http://www.cs.ucsb.edu/~rich/class/cs170/)
 
-<a id="" href="#">^</a>2 - Used as the reference for
+<a id="" href="#ref">^</a>2 - Used as the reference for
 
 - [TOM-2.1-CS at UT](https://wwwhome.ewi.utwente.nl/~pieter/CS-OS/)
 - [CS 372 at UT Austin](http://www.cs.utexas.edu/users/witchel/372/) although certain readings are from [1] as well.
 
-<a id="" href="#">^</a>3 - [**OSTEP**](http://pages.cs.wisc.edu/~remzi/OSTEP/) was made as a companion for a [course on Operating Systems at UWISC](http://pages.cs.wisc.edu/~remzi/Classes/537/Spring2018/), which is freely available. The professors also recommend reading classic texts such as **Linux Kernel Development** and **The C Programming Language** (K&R). It is also used as a reference for [WPI's CS 3013](https://web.cs.wpi.edu/~cshue/cs3013/). Apart from being my personal recommendation for an introduction to Operating Systems, it is also recommended over at [Teach Yourself Computer Science](https://teachyourselfcs.com/£oeprating-systems) (_TYCS_).
+<a id="" href="#ref">^</a>3 - [**OSTEP**](http://pages.cs.wisc.edu/~remzi/OSTEP/) was made as a companion for a [course on Operating Systems at UWISC](http://pages.cs.wisc.edu/~remzi/Classes/537/Spring2018/), which is freely available. The professors also recommend reading classic texts such as **Linux Kernel Development** and **The C Programming Language** (K&R). It is also used as a reference for [WPI's CS 3013](https://web.cs.wpi.edu/~cshue/cs3013/). Apart from being my personal recommendation for an introduction to Operating Systems, it is also recommended over at [Teach Yourself Computer Science](https://teachyourselfcs.com/£oeprating-systems) (_TYCS_).
 
-<a id="" href="#">^</a>4 - Used as the reference for
+<a id="" href="#ref">^</a>4 - Used as the reference for
 
 - [SU's CS140](http://web.stanford.edu/~ouster/cgi-bin/cs140-spring18/index.php)
 - [Yale's CS422/522](http://flint.cs.yale.edu/cs422/)
 
-<a id="" href="#">^</a>5 - Used as the reference for
+<a id="" href="#ref">^</a>5 - Used as the reference for
 
 - [CS 161 at HU](http://www.eecs.harvard.edu/~cs161/)
 
-<a id="" href="#">^</a>6 - Basically a cheaper version of [1] recommended as the reference textbook for [CU's COMS W4118](http://www.cs.columbia.edu/~jae/4118/).
+<a id="" href="#ref">^</a>6 - Basically a cheaper version of [1] recommended as the reference textbook for [CU's COMS W4118](http://www.cs.columbia.edu/~jae/4118/).
 
 ## Data Communication
 <!-- Data transmission fundamentals: historical overview; time/frequency representation of data signals; elements of a communications link; definition of key terms; factors affecting system design, Binary and multi-level signaling: information transfer rate; calculation of channel capacity; bandwidth efficiency, Baseband data transmission: the problem of inter symbol interference; achieving a Nyquist channel response; recovery of symbols from noise; bit error rate performance for baseband data systems, Bandpass digital modulation: binary modulation schemes (eg ASK, FSK, PSK); multi-level digital modulation (e.g. M-ary ASK, M-ary FSK, M-ary PSK, QAM), Coding theory and practice: source coding; channel coding; block coding; convolutional coding; combined coding and modulation, Multi-user digital modulation techniques such as frequency division multiple access (FDMA); time division multiple access (TDMA); code division multiple access (CDMA); combined multiple access systems; Error detection and correction, Digital transmission fundamental  -->
@@ -431,14 +431,14 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 1. **Data Communication, Computer Networks and Open Systems** - Fred Halsall
 2. **TCP/IP Protocol Suite** - B. A. Forouzan
-3. **Data and Computer Communications** - William Stallings <sup id="">[[1]](#)</sup>
+3. **Data and Computer Communications** - William Stallings <sup id="ref">[[1]](#)</sup>
 4. **Communication Networks, Fundamental Concepts & Key Architecture** - Leon-Garcia and I. Widjaja
 
 ### Notes
 
 - Please help. I found nothing on the web with similar syllabus, which has been commented out. See source code.
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="" href="#ref">^</a>1 - Used as the reference for
 
 - [CS 3413 at UTSA](http://www.cs.utsa.edu/~korkmaz/teaching/cs3413/)
 
@@ -446,9 +446,9 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 ### Standard Textbooks
 
-1. **The Intel Microprocessors - Architecture Programming And Interfacing** - Barry B. Brey <sup id="">[[1]](#)</sup>
+1. **The Intel Microprocessors - Architecture Programming And Interfacing** - Barry B. Brey <sup id="ref">[[1]](#)</sup>
 2. **Microprocessor and Interfacing** - D. V. Hall
-3. **Microprocessor Architecture, Programming, and Applications with the 8085** - Ramesh Gaonkar <sup id="">[[5]](#)</sup>
+3. **Microprocessor Architecture, Programming, and Applications with the 8085** - Ramesh Gaonkar <sup id="ref">[[5]](#)</sup>
 
 ### Alternative/Supplementary
 
@@ -463,11 +463,11 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 Online courses about Microprocessors are rather difficult to come by.
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="" href="#ref">^</a>1 - Used as the reference for
 
 - [a course at UCF](http://www.cs.ucf.edu/~ahossam/teaching/microp/)
 
-<a id="" href="#">^</a>5 - Used as the reference for
+<a id="" href="#ref">^</a>5 - Used as the reference for
 
 - [IITK's CS43003](http://www.facweb.iitkgp.ernet.in/~apal/files/microprocessor_04.pdf) (Note: Syllabus page only)
 
@@ -475,21 +475,21 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Discrete Mathematics and Its Applications** - Kenneth H. Rosen <sup id="">[[1]](#)</sup>
-2. **Discrete Mathematics** - Kevin Ferland <sup id="">[[2]](#)</sup>
-3. **Mathematics for Computer Science** - Eric Lehman, F. Thomson Leighton, and Albert R. Meyer <sup id="">[[3]](#)</sup>
+1. **Discrete Mathematics and Its Applications** - Kenneth H. Rosen <sup id="ref">[[1]](#)</sup>
+2. **Discrete Mathematics** - Kevin Ferland <sup id="ref">[[2]](#)</sup>
+3. **Mathematics for Computer Science** - Eric Lehman, F. Thomson Leighton, and Albert R. Meyer <sup id="ref">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **Discrete and Combinatorial Mathematics: An Applied Introduction** - Ralph P. Grimaldi <sup id="">[[4]](#)</sup>
-2. **Discrete Mathematics for Computer Science** - Kenneth Bogart and Robert L. Drysdale <sup id="">[[5]](#)</sup>
-3. **Concrete Mathematics** - Ronald Graham, Donald E. Knuth and Oren Patashnik <sup id="">[[6]](#)</sup>
-4. **Discrete Mathematics** - Jiří Matoušek and Jaroslav Nešetřil <sup id="">[[7]](#)</sup>
-5. **Mathematical Structures for Computer Science** - J. L. Gersting <sup id="">[[8]](#)</sup>
-6. **Discrete Mathematics** - Norman L. Biggs <sup id="">[[9]](#)</sup>
-7. **Discrete Mathematics** - Kenneth A. Ross and Charles R. Wright <sup id="">[[10]](#)</sup>
-8. **Discrete Mathematics** - Seymour Lipschutz and Mar Lars Lipson <sup id="">[[11]](#)</sup>
-9. **Discrete Mathematics: Mathematical Reasoning and Proof with Puzzles, Patterns and Games** - Douglas E. Ensley and J. Winston Crawley <sup id="">[[12]](#)</sup>
+1. **Discrete and Combinatorial Mathematics: An Applied Introduction** - Ralph P. Grimaldi <sup id="ref">[[4]](#)</sup>
+2. **Discrete Mathematics for Computer Science** - Kenneth Bogart and Robert L. Drysdale <sup id="ref">[[5]](#)</sup>
+3. **Concrete Mathematics** - Ronald Graham, Donald E. Knuth and Oren Patashnik <sup id="ref">[[6]](#)</sup>
+4. **Discrete Mathematics** - Jiří Matoušek and Jaroslav Nešetřil <sup id="ref">[[7]](#)</sup>
+5. **Mathematical Structures for Computer Science** - J. L. Gersting <sup id="ref">[[8]](#)</sup>
+6. **Discrete Mathematics** - Norman L. Biggs <sup id="ref">[[9]](#)</sup>
+7. **Discrete Mathematics** - Kenneth A. Ross and Charles R. Wright <sup id="ref">[[10]](#)</sup>
+8. **Discrete Mathematics** - Seymour Lipschutz and Mar Lars Lipson <sup id="ref">[[11]](#)</sup>
+9. **Discrete Mathematics: Mathematical Reasoning and Proof with Puzzles, Patterns and Games** - Douglas E. Ensley and J. Winston Crawley <sup id="ref">[[12]](#)</sup>
 10. **Elements of Discrete Mathematics: A Computer Oriented Approach** - C. L. Liu and D. P. Mohapatra
 11. **Discrete Mathematical Structures with Applications, to Computer Science** - J. P. Tremblay and R. Manohar
 12. **Discrete Mathematics for Computer Scientists & Mathematics** - Joe L. Mott, A. Kandel, and T. P. Baker
@@ -515,7 +515,7 @@ Online courses about Microprocessors are rather difficult to come by.
 - Cornell also hosts a useful set of [notes on Discrete Structures](https://www.cs.cornell.edu/~rafael/discmath.pdf).
 - [UT Austin's CS 311](http://www.cs.utexas.edu/~vl/teaching/311/) appears to have their own set of lecture notes linked on the course page.
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="" href="#ref">^</a>1 - Used as the reference for
 
 - [CS381 at ODU](http://www.cs.odu.edu/~cs381/index.html)
 - [CSE 191 at UaB](https://cse.buffalo.edu/~rapaport/191/) with [11] additionally recommended
@@ -523,35 +523,35 @@ Online courses about Microprocessors are rather difficult to come by.
 - [14:332:312 at Rutgers](http://eceweb1.rutgers.edu/~csi/DiscMath.html)
 - [CS 441 at PU](https://people.cs.pitt.edu/~milos/courses/cs441/)
 - [CS 70 at Berkeley](http://eecs70.org/) although notes are recommended for primary reading
-- [CS 207 at IIT Bombay](https://www.cse.iitb.ac.in/~akshayss/courses/cs207-2016.html) along with <sup id="">[[9]](#)</sup>
+- [CS 207 at IIT Bombay](https://www.cse.iitb.ac.in/~akshayss/courses/cs207-2016.html) along with <sup id="ref">[[9]](#)</sup>
 
-<a id="" href="#">^</a>3 - Used as the reference for
+<a id="" href="#ref">^</a>3 - Used as the reference for
 
 - [CS2102 at UoV](https://uvacs2102.github.io/) and has generously been made [available online](https://uvacs2102.github.io/docs/mcs.pdf) under the Creative Commons License
 - [CS1010 at IITH](https://www.iith.ac.in/~aravind/cs1010.html) although it uses [slightly older notes](https://www.iith.ac.in/~aravind/Files-DM/LLM-MFCS-2012.pdf) instead with an additional guide on [**How to write Mathematics**](http://erickson.sites.truman.edu/files/2012/04/guide1.pdf) by Martin Erickson
 - [CS 30 at Dartmouth](https://www.cs.dartmouth.edu/~ac/Teach/CS30-Winter18/) with [1] recommended for additional reading
 
-<a id="" href="#">^</a>4 - Used as the reference for
+<a id="" href="#ref">^</a>4 - Used as the reference for
 
 - [Discrete Structures and Combinatorics at BGU](https://www.cs.bgu.ac.il/~dsc172/Main) along with some weird Israeli book? :shrug:
 
-<a id="" href="#">^</a>5 - Used as the reference for
+<a id="" href="#ref">^</a>5 - Used as the reference for
 
 - [CPS 102 at Duke](https://www2.cs.duke.edu/courses/spring09/cps102/) with [1], [6] and [7] also recommended
 
-<a id="" href="#">^</a>8 - Used as the reference for
+<a id="" href="#ref">^</a>8 - Used as the reference for
 
 - [MAT 385 at NKU](http://ceadserv1.nku.edu/longa//classes/2002fall/mat385/)
 
-<a id="" href="#">^</a>9 - Used as the reference for
+<a id="" href="#ref">^</a>9 - Used as the reference for
 
 - [Discrete Math at Cambridge](https://www.cl.cam.ac.uk/teaching/1314/DiscMath/) with additional books listed
 
-<a id="" href="#">^</a>10 - Used as the reference for
+<a id="" href="#ref">^</a>10 - Used as the reference for
 
 - [Discrete Mathematics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/discretemaths/) along with other recommendations like [^](#)4
 
-<a id="" href="#">^</a>12 - Used as the reference for
+<a id="" href="#ref">^</a>12 - Used as the reference for
 
 - [CSCI 2824 at UoC Boulder](https://www.colorado.edu/cs/csci-2824-discrete-structures)
 
@@ -559,22 +559,22 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Computer Graphics: Principles and Practice** - John F. Hughes, Andries van Dam, Morgan McGuire, David F. Sklar, James D. Foley, Steven K. Feiner, Kurt Akeley <sup id="">[[1]](#)</sup>
-2. **Fundamentals of Computer Graphics** - Pete Shirley and Steve Marschner with Michael Ashikhmin, Michael Gleicher, Naty Hoffman, Garrett Johnson, Tamara Munzner, Erik Reinhard, Kelvin Sung, William B. Thompson, Peter Willemsen, and Bryan Wyvill <sup id="">[[2]](#)</sup>
-3. **Computer Graphics, C Version** - Donald Hearn and M. Pauline Baker <sup id="">[[3]](#)</sup>
+1. **Computer Graphics: Principles and Practice** - John F. Hughes, Andries van Dam, Morgan McGuire, David F. Sklar, James D. Foley, Steven K. Feiner, Kurt Akeley <sup id="ref">[[1]](#)</sup>
+2. **Fundamentals of Computer Graphics** - Pete Shirley and Steve Marschner with Michael Ashikhmin, Michael Gleicher, Naty Hoffman, Garrett Johnson, Tamara Munzner, Erik Reinhard, Kelvin Sung, William B. Thompson, Peter Willemsen, and Bryan Wyvill <sup id="ref">[[2]](#)</sup>
+3. **Computer Graphics, C Version** - Donald Hearn and M. Pauline Baker <sup id="ref">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **Computer Graphics using Open GL** - Francis S. Hill <sup id="">[[4]](#)</sup>
-2. **Multimedia Systems** - R. Steinmetz and K. Nahrstedt <sup id="">[[5]](#)</sup>
-3. **Fundamentals of Multimedia** - Ze-Nian Li and M. S. Drew <sup id="">[[6]](#)</sup>
-4. **Mathematical Elements for Computer Graphics** - David F. Rogers and James Alan Adams <sup id="">[[7]](#)</sup>
-5. **Physically Based Rendering: From Theory to Implementation** - Matt Pharr and Greg Humphreys <sup id="">[[8]](#)</sup>
-6. **Procedural Elements for Computer Graphics** - David Rogers <sup id="">[[9]](#)</sup>
-7. **Computer Graphics for Java Programmers** - L. Ammeraal and K. Zhang <sup id="">[[10]](#)</sup>
-8. **Computer Graphics: A Survey of Current Techniques and Applications** - John Lewell <sup id="">[[11]](#)</sup>
-9. **Computer Graphics: Theory Into Practice** - Jeffrey J. McConnell <sup id="">[[12]](#)</sup>
-10. **Computer Graphics: Techniques and Applications** - R. D. Parslow, R. W. Prowse, Richard Elliot Green [13]
+1. **Computer Graphics using Open GL** - Francis S. Hill <sup id="ref">[[4]](#)</sup>
+2. **Multimedia Systems** - R. Steinmetz and K. Nahrstedt <sup id="ref">[[5]](#)</sup>
+3. **Fundamentals of Multimedia** - Ze-Nian Li and M. S. Drew <sup id="ref">[[6]](#)</sup>
+4. **Mathematical Elements for Computer Graphics** - David F. Rogers and James Alan Adams <sup id="ref">[[7]](#)</sup>
+5. **Physically Based Rendering: From Theory to Implementation** - Matt Pharr and Greg Humphreys <sup id="ref">[[8]](#)</sup>
+6. **Procedural Elements for Computer Graphics** - David Rogers <sup id="ref">[[9]](#)</sup>
+7. **Computer Graphics for Java Programmers** - L. Ammeraal and K. Zhang <sup id="ref">[[10]](#)</sup>
+8. **Computer Graphics: A Survey of Current Techniques and Applications** - John Lewell <sup id="ref">[[11]](#)</sup>
+9. **Computer Graphics: Theory Into Practice** - Jeffrey J. McConnell <sup id="ref">[[12]](#)</sup>
+10. **Computer Graphics: Techniques and Applications** - R. D. Parslow, R. W. Prowse, Richard Elliot Green <sup id=ref"">[[13]]</sup>
 11. **Computer graphics and virtual environments: from realism to real-time** - M. Slater, A. Steed, Y. Chrysantho [14]
 12. **Interactive environments with open-source software** - Wolfgang Höhl [15]
 13. **Foundations of 3D Computer Graphics** - Steven J. Gortler [16]
@@ -586,7 +586,7 @@ Online courses about Microprocessors are rather difficult to come by.
 
 - There is a reference book for OpenGL programming one may find useful called the "[Red Book](http://www.opengl.org/documentation/red_book/)". Many courses have further resources like these linked on their course or info pages.
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="" href="#ref">^</a>1 - Used as the reference for
 
 - [CSCI 1230 at Brown](https://cs.brown.edu/courses/cs123/)
 - [CS4620/CS4621 at Cornell](http://www.cs.cornell.edu/courses/cs4620/2014fa/index.shtml) along with [16]
@@ -594,17 +594,17 @@ Online courses about Microprocessors are rather difficult to come by.
 - [Introduction to Computer Graphics at UIC](https://www.cs.uic.edu/~jbell/CourseNotes/ComputerGraphics/index.html)
 - [CS 488 at UIC](https://www.evl.uic.edu/aej/488/index.html) which seems to be an earlier version of the course above
 
-<a id="" href="#">^</a>2 - Used as the reference for
+<a id="" href="#ref">^</a>2 - Used as the reference for
 
-- [CMU 15-462/662](http://15462.courses.cs.cmu.edu/fall2015/) along with [1] and <sup id="">[[8]](#)</sup>
+- [CMU 15-462/662](http://15462.courses.cs.cmu.edu/fall2015/) along with [1] and <sup id="ref">[[8]](#)</sup>
 - [Computer Graphics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/graphics/) with [1] and others additionally recommended
 - [CS248 at Stanford](http://graphics.stanford.edu/courses/cs248-18-spring/) with [1] also recommended
 
-<a id="" href="#">^</a>16 - Used as the reference for
+<a id="" href="#ref">^</a>16 - Used as the reference for
 
 - [CS 175 at Harvard](https://sites.fas.harvard.edu/~lib175/) taught by Steven Gortler himself
 
-<a id="" href="#">^</a>17 - Used as the reference for
+<a id="" href="#ref">^</a>17 - Used as the reference for
 
 - [CS 465 at Bilkent](http://www.cs.bilkent.edu.tr/~gudukbay/cs465/)
 - [EDAF80 at LTH](http://cs.lth.se/edaf80/) with [The Graphics Codex](http://graphicscodex.com/) linked for additional reading
@@ -615,8 +615,8 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Elements of Information Theory** - T. M. Cover and J. A. Thomas <sup id="">[[1]](#)</sup>
-2. **Information Theory, Inference and Learning Algorithms** - David J. C. Mackay <sup id="">[[2]](#)</sup>
+1. **Elements of Information Theory** - T. M. Cover and J. A. Thomas <sup id="ref">[[1]](#)</sup>
+2. **Information Theory, Inference and Learning Algorithms** - David J. C. Mackay <sup id="ref">[[2]](#)</sup>
 3. **Information Theory Coding and Cryptography** - R. Bose
 
 ### Alternative/Supplementary
@@ -625,9 +625,9 @@ Online courses about Microprocessors are rather difficult to come by.
 2. **Introduction to Data Compression** - Khalid Sayood
 3. **The Theory of Information and Coding** - R. J. McEliece
 4. **The Theory of Error Correcting Codes** - F. J. MacWilliams and N. J. A. Sloane
-5. **Entropy and Information Theory** - Robert M. Gray <sup id="">[[3]](#)</sup>
-6. **Information Theory and Reliable Communication** - R. G. Gallagher <sup id="">[[4]](#)</sup>
-7. **Information Theory** - Robert B. Ash <sup id="">[[5]](#)</sup>
+5. **Entropy and Information Theory** - Robert M. Gray <sup id="ref">[[3]](#)</sup>
+6. **Information Theory and Reliable Communication** - R. G. Gallagher <sup id="ref">[[4]](#)</sup>
+7. **Information Theory** - Robert B. Ash <sup id="ref">[[5]](#)</sup>
 
 ### Notes
 
@@ -637,7 +637,7 @@ Online courses about Microprocessors are rather difficult to come by.
 - Most of the courses strongly recommend reading through Claude Shannon's [A Mathematical Theory of Communication](math.harvard.edu/~ctm/home/text/others/shannon/entropy/entropy.pdf) paper from 1948. It serves as the basis for the branch of Information Theory and Coding related research.
 - Most/All of the courses have relevant additional resources which are very useful
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="" href="#ref">^</a>1 - Used as the reference for
 
 - [15-859 at CMU](http://www.cs.cmu.edu/~venkatg/teaching/ITCS-spr2013/) with many other classic papers recommended for reading
 - [CSE 533 at UoW](https://catalyst.uw.edu/workspace/anuprao/15415/86593) with [a list of papers](https://catalyst.uw.edu/workspace/anuprao/15415/86644)
@@ -653,7 +653,7 @@ Online courses about Microprocessors are rather difficult to come by.
 - [EECS 428 at NWU](https://www.mccormick.northwestern.edu/eecs/courses/descriptions/428.html) (Note: Syllabus page only)
 - [ECE 563 at UoI](https://ece.illinois.edu/academics/courses/profile/ece563) (Note: Syllabus page only)
 
-<a id="" href="#">^</a>2 - Used as a reference for
+<a id="" href="#ref">^</a>2 - Used as a reference for
 
 - [COMP 7404 at DU](http://web.cs.du.edu/~ramki/courses/tpcs/infoTheory/index.html)
 - [CSC 310 at UoT](https://www.cs.toronto.edu/~radford/csc310.F11/) with [3] recommended for rigorous mathematical analysis
@@ -663,9 +663,9 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Compilers: Principles, Techniques, and Tools** - A. V. Aho, Ravi Sethi & Jeffrey D. Ullman <sup id="">[[1]](#)</sup>
+1. **Compilers: Principles, Techniques, and Tools** - A. V. Aho, Ravi Sethi & Jeffrey D. Ullman <sup id="ref">[[1]](#)</sup>
 2. **Compiler Construction Principles and Practice** - K. C. Louden
-3. **Modern compiler implementation in ML** - A. W. Appel <sup id="">[[2]](#)</sup>
+3. **Modern compiler implementation in ML** - A. W. Appel <sup id="ref">[[2]](#)</sup>
 
 ### Alternative/Supplementary
 
@@ -675,13 +675,13 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Notes
 
-<a id="" href="#">^</a>1 - This is a brilliant book recommended by [pearson.com](https://www.pearson.com/us/higher-education/program/Aho-Compilers-Principles-Techniques-and-Tools-2nd-Edition/PGM167067.html). Used as the reference for
+<a id="" href="#ref">^</a>1 - This is a brilliant book recommended by [pearson.com](https://www.pearson.com/us/higher-education/program/Aho-Compilers-Principles-Techniques-and-Tools-2nd-Edition/PGM167067.html). Used as the reference for
 
 - [CS143 at Stanford University](https://web.stanford.edu/class/cs143/)
 - [CS4120 at Cornell University](http://www.cs.cornell.edu/courses/cs4120/2013fa/)
 - [CS5470 at university of Utah](https://courses.engr.illinois.edu/cs421/fa2014/)
 
-<a id="" href="#">^</a>2 - Used as reference for
+<a id="" href="#ref">^</a>2 - Used as reference for
 
 - [CS421 at University of Illinois](https://courses.engr.illinois.edu/cs421/fa2014/)
 
@@ -689,55 +689,55 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Computer Networking: A Top-Down Approach** - James Kurose and Keith Ross <sup id="">[[1]](#)</sup>
-2. **Computer Networks – A System Approach** - Larry L. Peterson and Bruce S. Davie <sup id="">[[2]](#)</sup>
-3. **Computer Networks** - Andrew S. Tanenbaum <sup id="">[[3]](#)</sup>
+1. **Computer Networking: A Top-Down Approach** - James Kurose and Keith Ross <sup id="ref">[[1]](#)</sup>
+2. **Computer Networks – A System Approach** - Larry L. Peterson and Bruce S. Davie <sup id="ref">[[2]](#)</sup>
+3. **Computer Networks** - Andrew S. Tanenbaum <sup id="ref">[[3]](#)</sup>
 
 ### Alternative/Supplementary
 
 1. **TCP/IP protocol Suite** - Behrouz A. Forouzan
-2. **Data and Computer Communication** - William Stallings <sup id="">[[4]](#)</sup>
+2. **Data and Computer Communication** - William Stallings <sup id="ref">[[4]](#)</sup>
 3. **Data Communication, Computer Networks and Open Systems** - F. Halsall
-4. **Data Communications and Networking** - Behrouz A. Forouzan <sup id="">[[5]](#)</sup>
+4. **Data Communications and Networking** - Behrouz A. Forouzan <sup id="ref">[[5]](#)</sup>
 5. **Internetworking with TCP/IP, Volume 1** - Douglas Comer
-6. **TCP/IP Illustrated, Volume 1: The Protocols** - W. Richard Stevens <sup id="">[[6]](#)</sup>
-7. **Unix Network Programming, Volume 1: The Sockets Networking API** - W. Richard Stevens <sup id="">[[7]](#)</sup>
+6. **TCP/IP Illustrated, Volume 1: The Protocols** - W. Richard Stevens <sup id="ref">[[6]](#)</sup>
+7. **Unix Network Programming, Volume 1: The Sockets Networking API** - W. Richard Stevens <sup id="ref">[[7]](#)</sup>
 
 ### Notes
 
 [GATech's CS 6250](https://www.omscs.gatech.edu/cs-6250-computer-networks) has a list of useful papers [on Udacity](https://www.udacity.com/wiki/ud819/resources). There are also many more amazing resources on the web.
 
-<a id="" href="#">^</a>1 - It is recommended over at [TYCS](https://teachyourselfcs.com/#networking). Also used as the reference for
+<a id="" href="#ref">^</a>1 - It is recommended over at [TYCS](https://teachyourselfcs.com/#networking). Also used as the reference for
 
 - [CS60 at Dartmouth](http://www.cs.dartmouth.edu/~campbell/cs60/) where texts on Shell Scripting like **A Practical Guide to Linux Commands, Editors, and Shell Programming** by Mark G. Sobell are also recommended
 - [CS 356 at UT Austin](http://www.cs.utexas.edu/users/lam/cs356/)
 - [COS 461 at Princeton](https://www.cs.princeton.edu/courses/archive/spring17/cos461/) along with [^](#)2
 - [CS244A at Stanford](http://web.stanford.edu/class/cs244a/)
 
-<a id="" href="#">^</a>2 - Used as the reference for
+<a id="" href="#ref">^</a>2 - Used as the reference for
 
 - [15-441 at CMU](https://www.cs.cmu.edu/~prs/15-441-F16/)
-- [Computer Networks at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/networks/) along with <sup id="">[[3]](#)</sup>
+- [Computer Networks at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/networks/) along with <sup id=ref"">[[3]](#)</sup>
 - [CS 640 at UWISC](http://pages.cs.wisc.edu/~pb/cs640.html)
 
-<a id="" href="#">^</a>4 - Used as the reference for
+<a id="" href="#ref">^</a>4 - Used as the reference for
 
 - [CS 408 at SU](http://people.sabanciuniv.edu/levi/cs408/)
 
-<a id="" href="#">^</a>5 - It is regarded as the standard textbook in the field [according to Wikipedia](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Networking).
+<a id="" href="#ref">^</a>5 - It is regarded as the standard textbook in the field [according to Wikipedia](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Networking).
 
-<a id="" href="#">^</a>6, [7] - Widely recommended in many courses listed above for additional reading, especially those at Princeton, Stanford and UWISC.
+<a id="" href="#ref">^</a>6, [7] - Widely recommended in many courses listed above for additional reading, especially those at Princeton, Stanford and UWISC.
 
 ## Software Engineering
 
 ### Standard Textbooks
 
-1. **Software Engineering A Practitioner’s Approach** - Roger S. Pressman <sup id="">[[1]](#)</sup>
-2. **Software Engineering** - Ian Sommerville <sup id="">[[2]](#)</sup>
+1. **Software Engineering A Practitioner’s Approach** - Roger S. Pressman <sup id="ref">[[1]](#)</sup>
+2. **Software Engineering** - Ian Sommerville <sup id="ref">[[2]](#)</sup>
 
 ### Alternative/Supplementary
 
-1. **An Integrated Approach to Software Engineering** - Pankaj Jalote <sup id="">[[3]](#)</sup>
+1. **An Integrated Approach to Software Engineering** - Pankaj Jalote <sup id="ref">[[3]](#)</sup>
 2. **Software Engineering Fundamentals** - A. Behferooz and F. J. Hudson
 3. **Fundamentals of Software Engineering** - Rajib Mall
 4. **Software Engineering** - Gaurav Gupta and Deepika Gupta
@@ -745,13 +745,13 @@ Online courses about Microprocessors are rather difficult to come by.
 6. **Software Engineering 1st Edition** - Udit Agarwal
 7. **Algebraic Methodology and Software Technology** - Grigore Rosu and Jose Meseguer
 8. **Software Design Methodology: From Principles to Architectural Styles** - Hong Zhu
-9. **Object-oriented Software Engineering : using UML, patterns, and Java** - Bernd Bruegge and Allen Dutoit <sup id="">[[4]](#)</sup>
-10. **The New Software Engineering** - Sue A. Conger <sup id="">[[5]](#)</sup>
-11. **The Pragmatic Programmer** - Dave Thomas and Andy Hunt <sup id="">[[6]](#)</sup>
-12. **Software Engineering** - Ivan Marsic <sup id="">[[7]](#)</sup>
-13. **Design Patterns:  Elements of Reusable Object-Oriented Software**-  E. Gamma, R. Helm, R. Johnson, and J. Vlissides <sup id="">[[8]](#)</sup>
-14. **Object-Oriented Software Engineering: Practical Software Development using UML and Java** - Timothy C. Lethbridge and Robert Laganière <sup id="">[[9]](#)</sup>
-15. **Fundamentals of Software Engineering** - Carlo Ghezzi <sup id="">[[10]](#)</sup>
+9. **Object-oriented Software Engineering : using UML, patterns, and Java** - Bernd Bruegge and Allen Dutoit <sup id="ref">[[4]](#)</sup>
+10. **The New Software Engineering** - Sue A. Conger <sup id="ref">[[5]](#)</sup>
+11. **The Pragmatic Programmer** - Dave Thomas and Andy Hunt <sup id="ref">[[6]](#)</sup>
+12. **Software Engineering** - Ivan Marsic <sup id="ref">[[7]](#)</sup>
+13. **Design Patterns:  Elements of Reusable Object-Oriented Software**-  E. Gamma, R. Helm, R. Johnson, and J. Vlissides <sup id="ref">[[8]](#)</sup>
+14. **Object-Oriented Software Engineering: Practical Software Development using UML and Java** - Timothy C. Lethbridge and Robert Laganière <sup id="ref">[[9]](#)</sup>
+15. **Fundamentals of Software Engineering** - Carlo Ghezzi <sup id="ref">[[10]](#)</sup>
 
 ### Notes
 
@@ -759,43 +759,43 @@ Online courses about Microprocessors are rather difficult to come by.
 - [CS32 at Brown](http://cs.brown.edu/courses/cs0320/) recommends **Effective Java** by Joshua Bloch for some reason. :shrug:
 - [EE 360F at UT Austin](http://users.ece.utexas.edu/~perry/education/SE-Intro/) has a list of papers and sections from multiple books as necessary readings for the course.
 
-<a id="" href="#">^</a>1 - Used as the reference for
+<a id="" href="#ref">^</a>1 - Used as the reference for
 
 - [15-413 at CMU](https://www.cs.cmu.edu/~aldrich/courses/413/)
 - [CS 501 at Cornell](http://www.cs.cornell.edu/courses/cs501/2000FA/index.html) along with other classic books like **The Mythical Man Month** by Frederick Brooks
 
-<a id="" href="#">^</a>2 - Used as the reference for
+<a id="" href="#ref">^</a>2 - Used as the reference for
 
 - [Introduction to Software Engineering at PSU](http://www.csci.psu.edu/seminars/fallnotes/SWEintro.pdf) (Note: Syllabus page only)
 
-<a id="" href="#">^</a>3 - Used as the reference for
+<a id="" href="#ref">^</a>3 - Used as the reference for
 
 - [CS 320 at UMass](https://people.cs.umass.edu/~brun/class/2013Spring/CS320/)
 
-<a id="" href="#">^</a>4 - Used as the reference for
+<a id="" href="#ref">^</a>4 - Used as the reference for
 
 - [CS223 at Warwick](http://web.iitd.ac.in/~sumeet/sm.pdf) (Note: Syllabus and lecture pdf only)
 
-<a id="" href="#">^</a>5 - Used as the reference for
+<a id="" href="#ref">^</a>5 - Used as the reference for
 
 - [CS302 at Saylor Academy](https://learn.saylor.org/mod/page/view.php?id=686)
 
-<a id="" href="#">^</a>6 - Used as the reference for
+<a id="" href="#ref">^</a>6 - Used as the reference for
 
 - [CSE 403 at UoW](https://courses.cs.washington.edu/courses/cse403/)
 
-[7] - A [free book](http://www.ece.rutgers.edu/~marsic/books/SE/book-SE_marsic.pdf) written by the instructor of [ECE 14:332:452 at Rutgers](http://www.ece.rutgers.edu/~marsic/Teaching/SE/).
+<a id="" href="#ref">^</a>7 - A [free book](http://www.ece.rutgers.edu/~marsic/books/SE/book-SE_marsic.pdf) written by the instructor of [ECE 14:332:452 at Rutgers](http://www.ece.rutgers.edu/~marsic/Teaching/SE/).
 
-<a id="" href="#">^</a>8 - Used as the reference for
+<a id="" href="#ref">^</a>8 - Used as the reference for
 
 - [CSE870 at MSU](http://www.cse.msu.edu/~cse870/index.php) along with many other articles from literature
 - [Foundations of Software Engineering at BGU](https://www.cs.bgu.ac.il/~fsen141/Main) along with many other textbooks
 
-<a id="" href="#">^</a>9 - Used as the reference for
+<a id="" href="#ref">^</a>9 - Used as the reference for
 
 - SEG 2100 at UoO which cannot be accessed. Instead the author provides supporting materials and other links [here](http://www.site.uottawa.ca/school/research/lloseng/).
 
-<a id="" href="#">^</a>10 - Used as the reference for
+<a id="" href="#ref">^</a>10 - Used as the reference for
 
 - [CSE2102 at UConn](http://www.engr.uconn.edu/~steve/Cse2102/cse2102.html)
 

--- a/Curriculum.md
+++ b/Curriculum.md
@@ -177,7 +177,7 @@
 - [Principles of Programming Langugages at DEIB-P](https://home.deib.polimi.it/pradella/PL.html) has a list of readings from every language and has a list of papers to go through. There is no recommended textbook from the list above.
 - [CS 152 at Harvard](https://www.seas.harvard.edu/courses/cs152/2018sp/index.html) uses notes for their readings but also recommends [^](#CPLref)2, [^](#TAPLref)5, [^](#FSPLref)6 and [^](#PLAIref)3 for additional reference.
 - [CS 6110 at Cornell](https://www.cs.cornell.edu/courses/cs6110/2018sp/index.html) has no required textbook but recommends [^](#FSPLref)6 and [^](#TAPLref)5 for additional reading.
-- A [free version](https://www.cs.cmu.edu/~jcr/tpl.html) of [^](#TOPLref)13 is available for reading. I was unable to find any related course material.
+- A [free version](https://www.cs.cmu.edu/~jcr/tpl.html) of [^](#TOPLref)13 is available for reading. Any related course material was not found.
 - [601.426/626 at JHU](http://pl.cs.jhu.edu/pl/index.shtml) use their own book created by a course instructor. The book itself is available under Creative Commons License [here](http://pl.cs.jhu.edu/pl/book/book.pdf).
 - An extensive list of resources can also be found at [Programming Language Theory](http://steshaw.org/plt/).
 
@@ -237,7 +237,7 @@
 3. **Computer Architecture and Organisation** - John. P. Hayes <sup id="COAref">[[6]](#COA)</sup>
 4. **Computer Systems Design and Architecture** - Vincent P Heuring and Harry F Jordan
 5. **Fundamentals of Computer Organization and Architecture** - Mostafa Abd-El-Barr and Hesham El-Rewini
-6. **Computer Systems: a Programmer’s Perspective** - Randal E. Bryant and David R. O’Hallaron <sup id="CSPPref">[[7]](#CSPP)</sup>
+6. **Computer Systems: A Programmer’s Perspective** - Randal E. Bryant and David R. O’Hallaron <sup id="CSPPref">[[7]](#CSPP)</sup>
 7. **Introduction to Computing Systems: From Bits and Gates to C and Beyond** - Patt and Patel <sup id="ITCPref">[[8]](#ITCP)</sup>
 8. **Structured Computer Organization** - Andrew S. Tanenbaum
 9. **The Principles of Computer Hardware** - A. Clements
@@ -248,7 +248,7 @@
 
 There are plenty more books than listed and more courses than I'd care to link.
 
-<a id="CAHP" href="#CAHPref">^</a>1 - Widely regarded as an authoritative reference for Computer Organisation and Architecture. It is written by Turing Award winning Computer Scientists David Patterson and John Hennessy, but also assumes the reader is already well versed with concepts of Computer Architecture. For the beginner, [^](#CODHref)2 is widely recommended as _the_ book to start with. Used as a reference for
+<a id="CAHP" href="#CAHPref">^</a>1 - Widely regarded as an authoritative reference for Computer Organisation and Architecture. It is written by Turing Award winning Computer Scientists David Patterson and John Hennessy, but also assumes the reader is already well versed with concepts of Computer Architecture. For the beginner, [^](#CODHPref)2 is widely recommended as _the_ book to start with. Used as a reference for
 
 - [CS146 at Harvard](http://www.eecs.harvard.edu/~dbrooks/cs146-spring2004/)
 
@@ -279,15 +279,15 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Standard Textbooks
 
-1. **Introduction to Algorithms** - Thomas Cormen, C. Leiserson, and R. Rivest and C. Stein (*CLRS*) <sup id="ref">[[1]](#)</sup>
-2. **Algorithm Design** - Jon Kleinberg and Éva Tardos (*KT*) <sup id="ref">[[2]](#)</sup>
-3. **Algorithms** - Christos Papadimitriou, Sanjoy Dasgupta, and Umesh Vazirani (*DPV*) <sup id="ref">[[3]](#)</sup>
+1. **Introduction to Algorithms** - Thomas Cormen, C. Leiserson, and R. Rivest and C. Stein (*CLRS*) <sup id="CLRSref">[[1]](#CLRS)</sup>
+2. **Algorithm Design** - Jon Kleinberg and Éva Tardos (*KT*) <sup id="KTref">[[2]](#KT)</sup>
+3. **Algorithms** - Christos Papadimitriou, Sanjoy Dasgupta, and Umesh Vazirani (*DPV*) <sup id="DPVref">[[3]](#DPV)</sup>
 
 ### Alternative/Supplementary
 
-1. **The Algorithm Design Manual** - Steven Skiena <sup id="ref">[[4]](#)</sup>
-2. **Algorithms** - Robert Sedgewick and Kevin Wayne <sup id="ref">[[5]](#)</sup>
-3. **Introduction to Algorithms: A Creative Approach** - Udi Manber <sup id="ref">[[6]](#)</sup>
+1. **The Algorithm Design Manual** - Steven Skiena <sup id="ADMref">[[4]](#ADM)</sup>
+2. **Algorithms** - Robert Sedgewick and Kevin Wayne <sup id="ASWref">[[5]](ASW#)</sup>
+3. **Introduction to Algorithms: A Creative Approach** - Udi Manber <sup id="IAACAref">[[6]](#IAACA)</sup>
 4. **Fundamentals of Computer Algorithms** - Ellis Horowitz, Sartaj Sahni and S. Rajasekaran
 5. **An Introduction to the Analysis of Algorithms** - Robert Sedgewick and Philippe Flajolet
 6. **Design and Analysis of Algorithm** - P. H. Dave and H. B. Dave
@@ -299,35 +299,35 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 - Algorithms are a vast topic and merit their own course altogether due to there being many subtopics such as randomised, parallel, approximation and so on, each having entire textbooks on them. This particular topic is meant to serve as an introduction to each subtopic by focusing on the underlying principles used in designing the algorithm. There are many MOOCs to cater to students, again linked [here]().
 - There are, again, numerous resources on the web related to the topic and if a major course related to it hasn't made it to the list, contributions are extremely welcome.
-- [CSC2420 at UoT](http://www.cs.toronto.edu/~bor/2420f12/) does not use a single source. Instead it uses a combination of [1], [3] and [2].
+- [CSC2420 at UoT](http://www.cs.toronto.edu/~bor/2420f12/) does not use a single source. Instead it uses a combination of [^](#CLRSref)1, [^](#DPVref)3 and [^](#KTref)2.
 - [5] is used as the basis for [Sedgewick and Wayne's online course on Coursera](https://www.coursera.org/teach/algorithms-part1) with a [second part](https://www.coursera.org/teach/algorithms-part2).
-- [2] has a revised version of slides to accompany the textbook available [here](http://www.cs.princeton.edu/~wayne/kleinberg-tardos/).
+- [^](#KTref)2 has a revised version of slides to accompany the textbook available [here](http://www.cs.princeton.edu/~wayne/kleinberg-tardos/).
 - [Algorithms, Etc. by Jeff Erickson](http://jeffe.cs.illinois.edu/teaching/algorithms/) is a set of notes that covers the material necessary for his course at University of Illinois.
 - *TAOCP* also serves as a useful reference for many algorithms typically studied as part of an undergraduate level course. It is quite mathematical so typically many students find it a hard read.
 
-<a id="" href="#ref">^</a>1 - Typically used as an encyclopedic reference for most topic, rather than an introduction to algorithms. Used as the reference for
+<a id="CLRS" href="#CLRSref">^</a>1 - Typically used as an encyclopedic reference for most topic, rather than an introduction to algorithms. Used as the reference for
 
 - [CS 600 A at SIT](https://www.cs.stevens.edu/~swetzel/CS600/spring11/)
-- [15-451/651 at CMU](https://www.cs.cmu.edu/~15451/) which also recommends [3] but either can be used, while an [older version](http://www.cs.cmu.edu/~avrim/451f09/index.html) has it's own set of notes
+- [15-451/651 at CMU](https://www.cs.cmu.edu/~15451/) which also recommends [^](#DPVref)3 but either can be used, while an [older version](http://www.cs.cmu.edu/~avrim/451f09/index.html) has it's own set of notes
 - [CS 466/666 at UoW](https://cs.uwaterloo.ca/~eblais/courses/F17/CS466/) with additional material described [here](https://cs.uwaterloo.ca/~eblais/courses/F17/CS466/outline.pdf)
 
-<a id="" href="#ref">^</a>2 - Used as the reference for
+<a id="KT" href="#KTref">^</a>2 - Used as the reference for
 
 - [CSci 256 at WC](https://www.cs.williams.edu/~lenhart/cs256/index.html)
-- [CPSC500 at UBC](http://www.cs.ubc.ca/~condon/cpsc500/) with [3] additionally recommended along with other texts
-- [CS 7200 at WU](http://cecs.wright.edu/~tkprasad/courses/cs7200/cs7200.html) with [1] additionally used for reference
+- [CPSC500 at UBC](http://www.cs.ubc.ca/~condon/cpsc500/) with [^](#DPVref)3 additionally recommended along with other texts
+- [CS 7200 at WU](http://cecs.wright.edu/~tkprasad/courses/cs7200/cs7200.html) with [^](#CLRSref)1 additionally used for reference
 - [CS 161 at Stanford](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms) where Tim has made his lecture videos available to all
 - [CS 7820 at Cornell](http://www.cs.cornell.edu/courses/cs6820/2009fa/) taken by **Jon Kleinberg**
 
-<a id="" href="#ref">^</a>3 - Used as the reference for
+<a id="DPV" href="#DPVref">^</a>3 - Used as the reference for
 
 - [CS 157 at Brown](https://cs.brown.edu/courses/cs157/)
 
-<a id="" href="#ref">^</a>4 - Recommended by *TYCS*. Used as the reference for
+<a id="ADM" href="#ADMref">^</a>4 - Recommended by [*TYCS*](https://teachyourselfcs.com/#algorithms). Used as the reference for
 
 - [CSE 373 at SUNY, SB](http://www3.cs.stonybrook.edu/~skiena/373/) which is taken by **Steven Skiena**
 
-<a id="" href="#ref">^</a>5 - Used as the reference for
+<a id="ASW" href="#ASWref">^</a>5 - Used as the reference for
 
 - [COS226 at Princeton](http://www.cs.princeton.edu/courses/archive/spring18/cos226/) with a [condensed version of the book](https://algs4.cs.princeton.edu/home/) available for reference
 
@@ -336,12 +336,12 @@ There are plenty more books than listed and more courses than I'd care to link.
 ### Standard Textbooks
 
 1. **Introduction to Automata Theory, Languages, and Computation** - John E. Hopcroft and Jeffrey D. Ullman (_The Cinderella Book_) <sup id="TCBref">[[1]](#TCB)</sup>
-2. **Introduction to the Theory of Computation** - Michael Sipser <sup id="ref">[[2]](#)</sup>
+2. **Introduction to the Theory of Computation** - Michael Sipser <sup id="TOCSref">[[2]](#TOCS)</sup>
 3. **Elements of the Theory of Computation** - Harry R. Lewis & C. H. Papadimitriou
 
 ### Alternative/Supplementary
 
-1. **Introduction to Formal Language and Computation** - Peter Linz <sup id="ref">[[4]](#)</sup>
+1. **Introduction to Formal Language and Computation** - Peter Linz <sup id="ITFLACref">[[3]](#ITFLAC)</sup>
 2. **Theory of Computer Science: Automata, Language and Computation** - Mishra & Chandrasekharan
 3. **A Text Book on Automata Theory** - Nasir & Sirmani
 4. **Introduction to Languages and The Theory of Computation** - John Martin
@@ -354,47 +354,45 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Notes
 
-<a id="" href="#ref">^</a>1 - Used a reference textbook for many courses around the world. It closely matches what Jeff Ullman [teaches online at Lagunita](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about). (Duh)
+<a id="TCB" href="#TCBref">^</a>1 - Used a reference textbook for many courses around the world. It closely matches what Jeff Ullman [teaches online at Lagunita](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+Fall2016/about). (Duh)
 
-<a id="" href="#ref">^</a>2 - Used as the reference for
+<a id="TOCS" href="#TOCref">^</a>2 - Used as the reference for
 
 - [CS 3102 at UoV](http://www.cs.virginia.edu/~robins/cs3102/)
 - [CS-251 at EPFL](http://theory.epfl.ch/cs251/Home.html)
 - [CS 3800 at NEU](https://course.ccs.neu.edu/cs3800f17wc/policies.html)
 - [CS39 at Dartmouth](https://www.cs.dartmouth.edu/~ac/Teach/CS39-Spring18/)
+- [AU's COMP 674](http://www.athabascau.ca/syllabi/comp/comp674.php), a graduate level course.
 
-<a id="" href="#ref">^</a>4 - Used as the reference for
+<a id="ITFLAC" href="#ITFLACref">^</a>3 - Used as the reference for
 
 - [UPenn's CSC 4170-50](https://www.seas.upenn.edu/~cit596/notes/dave/syllabus.html)
-
-<a id="" href="#ref">^</a>5 - Used as the reference for
-
-- [AU's COMP 674](http://www.athabascau.ca/syllabi/comp/comp674.php), a graduate level course.
 
 ## Operating Systems
 
 ### Standard Textbooks
 
-1. **Operating System Concepts** - J. L. Peterson and A. Silberschatz (*The Dinosaur Book*) <sup id="ref">[[1]](#)</sup>
+1. **Operating System Concepts** - J. L. Peterson and A. Silberschatz (*The Dinosaur Book*) <sup id="TDBref">[[1]](#TDB)</sup>
 2. **Modern Operating Systems** - Andrew S. Tanenbaum
-3. **Operating Systems, Internals and Design Principles** - William Stallings <sup id="ref">[[2]](#)</sup>
+3. **Operating Systems, Internals and Design Principles** - William Stallings <sup id="OSIDPref">[[2]](#OSIDP)</sup>
 
 ### Alternative/Supplementary
 
-1. **Operating Systems: Three Easy Pieces** - Remzi H. Arpaci-Dusseau and Andrea C. Arpaci-Dusseau (*The Black Book*/*The Asteroid Book*/*The Comet Book*) <sup id="ref">[[3]](#)</sup>
+1. **Operating Systems: Three Easy Pieces** - Remzi H. Arpaci-Dusseau and Andrea C. Arpaci-Dusseau (*The Black Book*/*The Asteroid Book*/*The Comet Book*) <sup id="OSTEPref">[[3]](#OSTEP)</sup>
 2. **Schaum’s Outline of Operating Systems** - Archer J. Harris
 3. **The Design of the UNIX operating system** - Maurice J. Bach
-4. **Operating Systems: Principles and Practice** - Thomas Anderson and Michael Dahlin. <sup id="ref">[[4]](#)</sup>
+4. **Operating Systems: Principles and Practice** - Thomas Anderson and Michael Dahlin. <sup id="OSPPref">[[4]](#OSPP)</sup>
 5. **Operating Systems: A Concept-Based Approach** - D. M. Dhamdhere
 6. **Operating Systems: A Modern Perspective** - Gary J. Nutt
-7. **Operating Systems In Depth: Design and Programming** - Thomas W. Doeppner <sup id="ref">[[5]](#)</sup>
-8. **Operating System Concepts Essentials** - Silberschatz, Galvin, Gagne <sup id="ref">[[6]](#)</sup>
+7. **Operating Systems In Depth: Design and Programming** - Thomas W. Doeppner <sup id="OSIDDPref">[[5]](#OSIDDP)</sup>
+8. **Operating System Concepts Essentials** - Silberschatz, Galvin, Gagne <sup id="OSCEref">[[6]](#OSCE)</sup>
 
 ### Notes
 
-For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Operating_systems) provides a list of a series of breakthroughs in Operating System Design. [A list of research papers on Udacity](https://www.udacity.com/wiki/ud156-readings) may also be useful, and are the recommended readings for [CS 6210 at GATech](https://www.omscs.gatech.edu/cs-6210-advanced-operating-systems).
+- For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Operating_systems) provides a list of a series of breakthroughs in Operating System Design.
+- [A list of research papers on Udacity](https://www.udacity.com/wiki/ud156-readings) may also be useful, and are the recommended readings for [CS 6210 at GATech](https://www.omscs.gatech.edu/cs-6210-advanced-operating-systems).
 
-<a id="" href="#ref">^</a>1 - Used as the reference for
+<a id="TDB" href="#TDBref">^</a>1 - Used as the reference for
 
 - [CS 385 at UIC](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems/)
 - [CM's 15-410](https://www.cs.cmu.edu/~410/)
@@ -402,23 +400,23 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 - [Drexel's CS 543](https://www.cs.drexel.edu/~jjohnson/2012-13/fall/cs543/) which again recommends reading **Linux Kernel Development**.
 - [CS170 at UCSB](http://www.cs.ucsb.edu/~rich/class/cs170/)
 
-<a id="" href="#ref">^</a>2 - Used as the reference for
+<a id="OSIDP" href="#OSIDPref">^</a>2 - Used as the reference for
 
 - [TOM-2.1-CS at UT](https://wwwhome.ewi.utwente.nl/~pieter/CS-OS/)
-- [CS 372 at UT Austin](http://www.cs.utexas.edu/users/witchel/372/) although certain readings are from [1] as well.
+- [CS 372 at UT Austin](http://www.cs.utexas.edu/users/witchel/372/) although certain readings are from [^](#TDB)1 as well.
 
-<a id="" href="#ref">^</a>3 - [**OSTEP**](http://pages.cs.wisc.edu/~remzi/OSTEP/) was made as a companion for a [course on Operating Systems at UWISC](http://pages.cs.wisc.edu/~remzi/Classes/537/Spring2018/), which is freely available. The professors also recommend reading classic texts such as **Linux Kernel Development** and **The C Programming Language** (K&R). It is also used as a reference for [WPI's CS 3013](https://web.cs.wpi.edu/~cshue/cs3013/). Apart from being my personal recommendation for an introduction to Operating Systems, it is also recommended over at [Teach Yourself Computer Science](https://teachyourselfcs.com/£oeprating-systems) (_TYCS_).
+<a id="OSTEP" href="#OSTEPref">^</a>3 - [**OSTEP**](http://pages.cs.wisc.edu/~remzi/OSTEP/) was made as a companion for [CS 537 at UWISC](http://pages.cs.wisc.edu/~remzi/Classes/537/Spring2018/), which is freely available. The professors also recommend reading classic texts such as **Linux Kernel Development** and **The C Programming Language** (K&R). It is also used as a reference for [WPI's CS 3013](https://web.cs.wpi.edu/~cshue/cs3013/). Apart from being my personal recommendation for an introduction to Operating Systems, it is also recommended over at [_TYCS_](https://teachyourselfcs.com/#operating-systems).
 
-<a id="" href="#ref">^</a>4 - Used as the reference for
+<a id="OSPP" href="#OSPPref">^</a>4 - Used as the reference for
 
 - [SU's CS140](http://web.stanford.edu/~ouster/cgi-bin/cs140-spring18/index.php)
 - [Yale's CS422/522](http://flint.cs.yale.edu/cs422/)
 
-<a id="" href="#ref">^</a>5 - Used as the reference for
+<a id="OSIDDP" href="#OSIDDPref">^</a>5 - Used as the reference for
 
 - [CS 161 at HU](http://www.eecs.harvard.edu/~cs161/)
 
-<a id="" href="#ref">^</a>6 - Basically a cheaper version of [1] recommended as the reference textbook for [CU's COMS W4118](http://www.cs.columbia.edu/~jae/4118/).
+<a id="OSCE" href="#OSCEref">^</a>6 - Basically a cheaper version of [^](#TDB)1 recommended as the reference textbook for [CU's COMS W4118](http://www.cs.columbia.edu/~jae/4118/).
 
 ## Data Communication
 <!-- Data transmission fundamentals: historical overview; time/frequency representation of data signals; elements of a communications link; definition of key terms; factors affecting system design, Binary and multi-level signaling: information transfer rate; calculation of channel capacity; bandwidth efficiency, Baseband data transmission: the problem of inter symbol interference; achieving a Nyquist channel response; recovery of symbols from noise; bit error rate performance for baseband data systems, Bandpass digital modulation: binary modulation schemes (eg ASK, FSK, PSK); multi-level digital modulation (e.g. M-ary ASK, M-ary FSK, M-ary PSK, QAM), Coding theory and practice: source coding; channel coding; block coding; convolutional coding; combined coding and modulation, Multi-user digital modulation techniques such as frequency division multiple access (FDMA); time division multiple access (TDMA); code division multiple access (CDMA); combined multiple access systems; Error detection and correction, Digital transmission fundamental  -->
@@ -431,14 +429,14 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 1. **Data Communication, Computer Networks and Open Systems** - Fred Halsall
 2. **TCP/IP Protocol Suite** - B. A. Forouzan
-3. **Data and Computer Communications** - William Stallings <sup id="ref">[[1]](#)</sup>
+3. **Data and Computer Communications** - William Stallings <sup id="DCCref">[[1]](#DCC)</sup>
 4. **Communication Networks, Fundamental Concepts & Key Architecture** - Leon-Garcia and I. Widjaja
 
 ### Notes
 
 - Please help. I found nothing on the web with similar syllabus, which has been commented out. See source code.
 
-<a id="" href="#ref">^</a>1 - Used as the reference for
+<a id="DCC" href="#DCCref">^</a>1 - Used as the reference for
 
 - [CS 3413 at UTSA](http://www.cs.utsa.edu/~korkmaz/teaching/cs3413/)
 
@@ -446,9 +444,9 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 ### Standard Textbooks
 
-1. **The Intel Microprocessors - Architecture Programming And Interfacing** - Barry B. Brey <sup id="ref">[[1]](#)</sup>
+1. **The Intel Microprocessors - Architecture Programming And Interfacing** - Barry B. Brey <sup id="TIMref">[[1]](#TIM)</sup>
 2. **Microprocessor and Interfacing** - D. V. Hall
-3. **Microprocessor Architecture, Programming, and Applications with the 8085** - Ramesh Gaonkar <sup id="ref">[[5]](#)</sup>
+3. **Microprocessor Architecture, Programming, and Applications with the 8085** - Ramesh Gaonkar <sup id="MAPAref">[[5]](#MAPA)</sup>
 
 ### Alternative/Supplementary
 
@@ -463,11 +461,11 @@ For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/w
 
 Online courses about Microprocessors are rather difficult to come by.
 
-<a id="" href="#ref">^</a>1 - Used as the reference for
+<a id="TIM" href="#TIMref">^</a>1 - Used as the reference for
 
 - [a course at UCF](http://www.cs.ucf.edu/~ahossam/teaching/microp/)
 
-<a id="" href="#ref">^</a>5 - Used as the reference for
+<a id="MAPA" href="#MAPAref">^</a>5 - Used as the reference for
 
 - [IITK's CS43003](http://www.facweb.iitkgp.ernet.in/~apal/files/microprocessor_04.pdf) (Note: Syllabus page only)
 
@@ -475,21 +473,21 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Discrete Mathematics and Its Applications** - Kenneth H. Rosen <sup id="ref">[[1]](#)</sup>
-2. **Discrete Mathematics** - Kevin Ferland <sup id="ref">[[2]](#)</sup>
-3. **Mathematics for Computer Science** - Eric Lehman, F. Thomson Leighton, and Albert R. Meyer <sup id="ref">[[3]](#)</sup>
+1. **Discrete Mathematics and Its Applications** - Kenneth H. Rosen <sup id="DMAIAref">[[1]](#DMAIA)</sup>
+2. **Discrete Mathematics** - Kevin Ferland <sup id="DMKFref">[[2]](#DMKF)</sup>
+3. **Mathematics for Computer Science** - Eric Lehman, F. Thomson Leighton, and Albert R. Meyer <sup id="MFCSref">[[3]](#MFCS)</sup>
 
 ### Alternative/Supplementary
 
-1. **Discrete and Combinatorial Mathematics: An Applied Introduction** - Ralph P. Grimaldi <sup id="ref">[[4]](#)</sup>
-2. **Discrete Mathematics for Computer Science** - Kenneth Bogart and Robert L. Drysdale <sup id="ref">[[5]](#)</sup>
-3. **Concrete Mathematics** - Ronald Graham, Donald E. Knuth and Oren Patashnik <sup id="ref">[[6]](#)</sup>
-4. **Discrete Mathematics** - Jiří Matoušek and Jaroslav Nešetřil <sup id="ref">[[7]](#)</sup>
-5. **Mathematical Structures for Computer Science** - J. L. Gersting <sup id="ref">[[8]](#)</sup>
-6. **Discrete Mathematics** - Norman L. Biggs <sup id="ref">[[9]](#)</sup>
-7. **Discrete Mathematics** - Kenneth A. Ross and Charles R. Wright <sup id="ref">[[10]](#)</sup>
-8. **Discrete Mathematics** - Seymour Lipschutz and Mar Lars Lipson <sup id="ref">[[11]](#)</sup>
-9. **Discrete Mathematics: Mathematical Reasoning and Proof with Puzzles, Patterns and Games** - Douglas E. Ensley and J. Winston Crawley <sup id="ref">[[12]](#)</sup>
+1. **Discrete and Combinatorial Mathematics: An Applied Introduction** - Ralph P. Grimaldi <sup id="DCMAAIref">[[4]](#DCMAAI)</sup>
+2. **Discrete Mathematics for Computer Science** - Kenneth Bogart and Robert L. Drysdale <sup id="DMCSBDref">[[5]](#DMCSBD)</sup>
+3. **Concrete Mathematics** - Ronald Graham, Donald E. Knuth and Oren Patashnik <sup id="CMGKPref">[[6]](#CMGKP)</sup>
+4. **Discrete Mathematics** - Jiří Matoušek and Jaroslav Nešetřil <sup id="DMMNref">[[7]](#DMMN)</sup>
+5. **Mathematical Structures for Computer Science** - J. L. Gersting <sup id="MSFCSref">[[8]](#MSFCS)</sup>
+6. **Discrete Mathematics** - Norman L. Biggs <sup id="DMNBref">[[9]](#DMNB)</sup>
+7. **Discrete Mathematics** - Kenneth A. Ross and Charles R. Wright <sup id="DMRWref">[[10]](#DMRW)</sup>
+8. **Discrete Mathematics** - Seymour Lipschutz and Mar Lars Lipson <sup id="DMLLref">[[11]](#DMLL)</sup>
+9. **Discrete Mathematics: Mathematical Reasoning and Proof with Puzzles, Patterns and Games** - Douglas E. Ensley and J. Winston Crawley <sup id="DMMRPPGref">[[12]](#DMMRPPG)</sup>
 10. **Elements of Discrete Mathematics: A Computer Oriented Approach** - C. L. Liu and D. P. Mohapatra
 11. **Discrete Mathematical Structures with Applications, to Computer Science** - J. P. Tremblay and R. Manohar
 12. **Discrete Mathematics for Computer Scientists & Mathematics** - Joe L. Mott, A. Kandel, and T. P. Baker
@@ -505,53 +503,53 @@ Online courses about Microprocessors are rather difficult to come by.
 22. **Practice Problems in Discrete Mathematics** - Bojana Obrenic
 23. **Hand Book of Discrete and Combinatorial Mathematics** - Kenneth H. Rosen and John G. Michaels
 24. **Discrete Mathematics by Example** - Andrew Simpson
-25. **Discrete mathematics with graph theory and combinatorics** - T. Veerarajan
+25. **Discrete Mathematics with Graph Theory and Combinatorics** - T. Veerarajan
 
 ### Notes
 
 - [Stanford's CS103](http://web.stanford.edu/class/cs103/) may serve as an introduction to those who are unfamiliar with the concepts.
-- Yale's CPSC 202 uses a [document of notes on Discrete Math as the primary reading](http://cs.yale.edu/homes/aspnes/classes/202/notes.pdf). Additional reading can be done from [2] or [1].
+- Yale's CPSC 202 uses a [document of notes on Discrete Math as the primary reading](http://cs.yale.edu/homes/aspnes/classes/202/notes.pdf). Additional reading can be done from [^](#DMKFref)2 or [^](#DMAIAref)1.
 - [CS20 at Harvard](https://www.seas.harvard.edu/courses/cs20/) uses [notes](https://www.seas.harvard.edu/courses/cs20/MIT6_042Notes.pdf) from [MIT's 6.042](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-042j-mathematics-for-computer-science-fall-2010/).
 - Cornell also hosts a useful set of [notes on Discrete Structures](https://www.cs.cornell.edu/~rafael/discmath.pdf).
 - [UT Austin's CS 311](http://www.cs.utexas.edu/~vl/teaching/311/) appears to have their own set of lecture notes linked on the course page.
 
-<a id="" href="#ref">^</a>1 - Used as the reference for
+<a id="DMAIA" href="#DMAIAref">^</a>1 - Used as the reference for
 
 - [CS381 at ODU](http://www.cs.odu.edu/~cs381/index.html)
-- [CSE 191 at UaB](https://cse.buffalo.edu/~rapaport/191/) with [11] additionally recommended
+- [CSE 191 at UaB](https://cse.buffalo.edu/~rapaport/191/) with [^](#DMLLref)11 additionally recommended
 - [6301 at UCL](https://www.ucl.ac.uk/maths/courses/undergraduates/modules/general-ancillary/general_ancillary_syllabuses/6301) (Note: Syllabus page only)
 - [14:332:312 at Rutgers](http://eceweb1.rutgers.edu/~csi/DiscMath.html)
 - [CS 441 at PU](https://people.cs.pitt.edu/~milos/courses/cs441/)
 - [CS 70 at Berkeley](http://eecs70.org/) although notes are recommended for primary reading
-- [CS 207 at IIT Bombay](https://www.cse.iitb.ac.in/~akshayss/courses/cs207-2016.html) along with <sup id="ref">[[9]](#)</sup>
+- [CS 207 at IIT Bombay](https://www.cse.iitb.ac.in/~akshayss/courses/cs207-2016.html) along with [^](#DMNBref)9
 
-<a id="" href="#ref">^</a>3 - Used as the reference for
+<a id="MFCS" href="#MFCSref">^</a>3 - Used as the reference for
 
 - [CS2102 at UoV](https://uvacs2102.github.io/) and has generously been made [available online](https://uvacs2102.github.io/docs/mcs.pdf) under the Creative Commons License
 - [CS1010 at IITH](https://www.iith.ac.in/~aravind/cs1010.html) although it uses [slightly older notes](https://www.iith.ac.in/~aravind/Files-DM/LLM-MFCS-2012.pdf) instead with an additional guide on [**How to write Mathematics**](http://erickson.sites.truman.edu/files/2012/04/guide1.pdf) by Martin Erickson
-- [CS 30 at Dartmouth](https://www.cs.dartmouth.edu/~ac/Teach/CS30-Winter18/) with [1] recommended for additional reading
+- [CS 30 at Dartmouth](https://www.cs.dartmouth.edu/~ac/Teach/CS30-Winter18/) with [^](#DMAIAref)1 recommended for additional reading
 
-<a id="" href="#ref">^</a>4 - Used as the reference for
+<a id="DCMAAI" href="#DCMAAIref">^</a>4 - Used as the reference for
 
-- [Discrete Structures and Combinatorics at BGU](https://www.cs.bgu.ac.il/~dsc172/Main) along with some weird Israeli book? :shrug:
+- [Discrete Structures and Combinatorics at BGU](https://www.cs.bgu.ac.il/~dsc172/Main) along with some weird Israeli book?
 
-<a id="" href="#ref">^</a>5 - Used as the reference for
+<a id="DMCSBD" href="#DMCSBDref">^</a>5 - Used as the reference for
 
-- [CPS 102 at Duke](https://www2.cs.duke.edu/courses/spring09/cps102/) with [1], [6] and [7] also recommended
+- [CPS 102 at Duke](https://www2.cs.duke.edu/courses/spring09/cps102/) with [^](#DMAIAref)1, [^](#CMGKref)6 and [^](#DMMNref)7 also recommended
 
-<a id="" href="#ref">^</a>8 - Used as the reference for
+<a id="MSFCS" href="#MSFCSref">^</a>8 - Used as the reference for
 
 - [MAT 385 at NKU](http://ceadserv1.nku.edu/longa//classes/2002fall/mat385/)
 
-<a id="" href="#ref">^</a>9 - Used as the reference for
+<a id="DMNB" href="#DMNBref">^</a>9 - Used as the reference for
 
 - [Discrete Math at Cambridge](https://www.cl.cam.ac.uk/teaching/1314/DiscMath/) with additional books listed
 
-<a id="" href="#ref">^</a>10 - Used as the reference for
+<a id="DMRW" href="#DMRWref">^</a>10 - Used as the reference for
 
-- [Discrete Mathematics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/discretemaths/) along with other recommendations like [^](#)4
+- [Discrete Mathematics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/discretemaths/) along with other recommendations like [^](#DCMAAIref)4
 
-<a id="" href="#ref">^</a>12 - Used as the reference for
+<a id="DMMRPPG" href="#DMMRPPGref">^</a>12 - Used as the reference for
 
 - [CSCI 2824 at UoC Boulder](https://www.colorado.edu/cs/csci-2824-discrete-structures)
 
@@ -559,52 +557,52 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Computer Graphics: Principles and Practice** - John F. Hughes, Andries van Dam, Morgan McGuire, David F. Sklar, James D. Foley, Steven K. Feiner, Kurt Akeley <sup id="ref">[[1]](#)</sup>
-2. **Fundamentals of Computer Graphics** - Pete Shirley and Steve Marschner with Michael Ashikhmin, Michael Gleicher, Naty Hoffman, Garrett Johnson, Tamara Munzner, Erik Reinhard, Kelvin Sung, William B. Thompson, Peter Willemsen, and Bryan Wyvill <sup id="ref">[[2]](#)</sup>
-3. **Computer Graphics, C Version** - Donald Hearn and M. Pauline Baker <sup id="ref">[[3]](#)</sup>
+1. **Computer Graphics: Principles and Practice** - John F. Hughes, Andries van Dam, Morgan McGuire, David F. Sklar, James D. Foley, Steven K. Feiner, Kurt Akeley <sup id="CGPPref">[[1]](#CGPP)</sup>
+2. **Fundamentals of Computer Graphics** - Pete Shirley and Steve Marschner with Michael Ashikhmin, Michael Gleicher, Naty Hoffman, Garrett Johnson, Tamara Munzner, Erik Reinhard, Kelvin Sung, William B. Thompson, Peter Willemsen, and Bryan Wyvill <sup id="FOCGref">[[2]](#FOCG)</sup>
+3. **Computer Graphics, C Version** - Donald Hearn and M. Pauline Baker <sup id="CGCVref">[[3]](#CGCV)</sup>
 
 ### Alternative/Supplementary
 
-1. **Computer Graphics using Open GL** - Francis S. Hill <sup id="ref">[[4]](#)</sup>
-2. **Multimedia Systems** - R. Steinmetz and K. Nahrstedt <sup id="ref">[[5]](#)</sup>
-3. **Fundamentals of Multimedia** - Ze-Nian Li and M. S. Drew <sup id="ref">[[6]](#)</sup>
-4. **Mathematical Elements for Computer Graphics** - David F. Rogers and James Alan Adams <sup id="ref">[[7]](#)</sup>
-5. **Physically Based Rendering: From Theory to Implementation** - Matt Pharr and Greg Humphreys <sup id="ref">[[8]](#)</sup>
-6. **Procedural Elements for Computer Graphics** - David Rogers <sup id="ref">[[9]](#)</sup>
-7. **Computer Graphics for Java Programmers** - L. Ammeraal and K. Zhang <sup id="ref">[[10]](#)</sup>
-8. **Computer Graphics: A Survey of Current Techniques and Applications** - John Lewell <sup id="ref">[[11]](#)</sup>
-9. **Computer Graphics: Theory Into Practice** - Jeffrey J. McConnell <sup id="ref">[[12]](#)</sup>
-10. **Computer Graphics: Techniques and Applications** - R. D. Parslow, R. W. Prowse, Richard Elliot Green <sup id=ref"">[[13]]</sup>
-11. **Computer graphics and virtual environments: from realism to real-time** - M. Slater, A. Steed, Y. Chrysantho [14]
-12. **Interactive environments with open-source software** - Wolfgang Höhl [15]
-13. **Foundations of 3D Computer Graphics** - Steven J. Gortler [16]
-14. **Interactive Computer Graphics, A Top-Down Approach with WebGL** - Edward Angel and Dave Schreiner [17]
+1. **Computer Graphics using Open GL** - Francis S. Hill
+2. **Multimedia Systems** - R. Steinmetz and K. Nahrstedt
+3. **Fundamentals of Multimedia** - Ze-Nian Li and M. S. Drew
+4. **Mathematical Elements for Computer Graphics** - David F. Rogers and James Alan Adams
+5. **Physically Based Rendering: From Theory to Implementation** - Matt Pharr and Greg Humphreys <sup id="PBRFTTIref">[[4]](#PBRFTTI)</sup>
+6. **Procedural Elements for Computer Graphics** - David Rogers
+7. **Computer Graphics for Java Programmers** - L. Ammeraal and K. Zhang
+8. **Computer Graphics: A Survey of Current Techniques and Applications** - John Lewell
+9. **Computer Graphics: Theory Into Practice** - Jeffrey J. McConnell
+10. **Computer Graphics: Techniques and Applications** - R. D. Parslow, R. W. Prowse, Richard Elliot Green
+11. **Computer Graphics and Virtual Environments: From Realism to Real-time** - M. Slater, A. Steed, Y. Chrysantho
+12. **Interactive Environments with Open-Source Software** - Wolfgang Höhl
+13. **Foundations of 3D Computer Graphics** - Steven J. Gortler <sup id="FOTDCGref">[[5]](#FOTDCG)</sup>
+14. **Interactive Computer Graphics, A Top-Down Approach with WebGL** - Edward Angel and Dave Schreiner <sup id="ICGATDAref">[[6]](#ICGATDA)</sup>
 
 ### Notes
 
-- The first two are no doubt standard textbooks in the field, but there is simply too vast an ocean of textbooks to categorise.
+- [^](#CGPPref)1 and [^](#FOCGref)2 are no doubt standard textbooks in the field, but there is simply too vast an ocean of textbooks to categorise.
+- There is a reference book for OpenGL programming one may find useful called the [_Red Book_](http://www.opengl.org/documentation/red_book/).
+- Many courses have further resources like these linked on their course or info pages.
 
-- There is a reference book for OpenGL programming one may find useful called the "[Red Book](http://www.opengl.org/documentation/red_book/)". Many courses have further resources like these linked on their course or info pages.
-
-<a id="" href="#ref">^</a>1 - Used as the reference for
+<a id="CGPP" href="#CGPPref">^</a>1 - Used as the reference for
 
 - [CSCI 1230 at Brown](https://cs.brown.edu/courses/cs123/)
-- [CS4620/CS4621 at Cornell](http://www.cs.cornell.edu/courses/cs4620/2014fa/index.shtml) along with [16]
-- [CS 6360 at IITM](http://www.cse.iitm.ac.in/~vplab/computer_graphics.html) along with [^](#)3
+- [CS4620/CS4621 at Cornell](http://www.cs.cornell.edu/courses/cs4620/2014fa/index.shtml) along with [^](#FOTDCGref)5
+- [CS 6360 at IITM](http://www.cse.iitm.ac.in/~vplab/computer_graphics.html) along with [^](#CGCVref)3
 - [Introduction to Computer Graphics at UIC](https://www.cs.uic.edu/~jbell/CourseNotes/ComputerGraphics/index.html)
 - [CS 488 at UIC](https://www.evl.uic.edu/aej/488/index.html) which seems to be an earlier version of the course above
 
-<a id="" href="#ref">^</a>2 - Used as the reference for
+<a id="FOCG" href="#FOCGref">^</a>2 - Used as the reference for
 
-- [CMU 15-462/662](http://15462.courses.cs.cmu.edu/fall2015/) along with [1] and <sup id="ref">[[8]](#)</sup>
-- [Computer Graphics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/graphics/) with [1] and others additionally recommended
-- [CS248 at Stanford](http://graphics.stanford.edu/courses/cs248-18-spring/) with [1] also recommended
+- [CMU 15-462/662](http://15462.courses.cs.cmu.edu/fall2015/) along with [^](#CGPPref)1 and [^](#PBRFTTIref)4
+- [Computer Graphics at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/graphics/) with [^](#CGPPref)1 and others additionally recommended
+- [CS248 at Stanford](http://graphics.stanford.edu/courses/cs248-18-spring/) with [^](#CGPPref)1 also recommended
 
-<a id="" href="#ref">^</a>16 - Used as the reference for
+<a id="FOTDCG" href="#FOTDCGref">^</a>5 - Used as the reference for
 
 - [CS 175 at Harvard](https://sites.fas.harvard.edu/~lib175/) taught by Steven Gortler himself
 
-<a id="" href="#ref">^</a>17 - Used as the reference for
+<a id="ICGATDA" href="#ICGATDAref">^</a>6 - Used as the reference for
 
 - [CS 465 at Bilkent](http://www.cs.bilkent.edu.tr/~gudukbay/cs465/)
 - [EDAF80 at LTH](http://cs.lth.se/edaf80/) with [The Graphics Codex](http://graphicscodex.com/) linked for additional reading

--- a/Curriculum.md
+++ b/Curriculum.md
@@ -372,7 +372,7 @@ There are plenty more books than listed and more courses than I'd care to link.
 
 ### Standard Textbooks
 
-1. **Operating System Concepts** - J. L. Peterson and A. Silberschatz (*The Dinosaur Book*) <sup id="TDBref">[[1]](#TDB)</sup>
+1. **Operating System Concepts** - J. L. Peterson and A. Silberschatz (*The Dinosaur Book*) <sup id="TOSDBref">[[1]](#TOSDB)</sup>
 2. **Modern Operating Systems** - Andrew S. Tanenbaum
 3. **Operating Systems, Internals and Design Principles** - William Stallings <sup id="OSIDPref">[[2]](#OSIDP)</sup>
 
@@ -392,7 +392,7 @@ There are plenty more books than listed and more courses than I'd care to link.
 - For a more historical approach, [this Wikipedia page](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Operating_systems) provides a list of a series of breakthroughs in Operating System Design.
 - [A list of research papers on Udacity](https://www.udacity.com/wiki/ud156-readings) may also be useful, and are the recommended readings for [CS 6210 at GATech](https://www.omscs.gatech.edu/cs-6210-advanced-operating-systems).
 
-<a id="TDB" href="#TDBref">^</a>1 - Used as the reference for
+<a id="TOSDB" href="#TOSDBref">^</a>1 - Used as the reference for
 
 - [CS 385 at UIC](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems/)
 - [CM's 15-410](https://www.cs.cmu.edu/~410/)
@@ -613,8 +613,8 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Elements of Information Theory** - T. M. Cover and J. A. Thomas <sup id="ref">[[1]](#)</sup>
-2. **Information Theory, Inference and Learning Algorithms** - David J. C. Mackay <sup id="ref">[[2]](#)</sup>
+1. **Elements of Information Theory** - T. M. Cover and J. A. Thomas <sup id="EOITref">[[1]](#EOIT)</sup>
+2. **Information Theory, Inference and Learning Algorithms** - David J. C. Mackay <sup id="ITILAref">[[2]](#ITILA)</sup>
 3. **Information Theory Coding and Cryptography** - R. Bose
 
 ### Alternative/Supplementary
@@ -623,9 +623,9 @@ Online courses about Microprocessors are rather difficult to come by.
 2. **Introduction to Data Compression** - Khalid Sayood
 3. **The Theory of Information and Coding** - R. J. McEliece
 4. **The Theory of Error Correcting Codes** - F. J. MacWilliams and N. J. A. Sloane
-5. **Entropy and Information Theory** - Robert M. Gray <sup id="ref">[[3]](#)</sup>
-6. **Information Theory and Reliable Communication** - R. G. Gallagher <sup id="ref">[[4]](#)</sup>
-7. **Information Theory** - Robert B. Ash <sup id="ref">[[5]](#)</sup>
+5. **Entropy and Information Theory** - Robert M. Gray <sup id="EAITref">[[3]](#EAIT)</sup>
+6. **Information Theory and Reliable Communication** - R. G. Gallagher
+7. **Information Theory** - Robert B. Ash
 
 ### Notes
 
@@ -633,37 +633,37 @@ Online courses about Microprocessors are rather difficult to come by.
 - A [Workshop on Complexity Information Theory in Theoretical Computer Science and Discrete Mathematics](http://sites.math.rutgers.edu/~saks/IT/) at Rutgers has an extensive reading list should one be ambitious enough.
 - [CS 229r at Harvard](http://people.seas.harvard.edu/~madhusudan/courses/Spring2016/) has links to notes from other courses and multiple papers on the topic.
 - Most of the courses strongly recommend reading through Claude Shannon's [A Mathematical Theory of Communication](math.harvard.edu/~ctm/home/text/others/shannon/entropy/entropy.pdf) paper from 1948. It serves as the basis for the branch of Information Theory and Coding related research.
-- Most/All of the courses have relevant additional resources which are very useful
+- Most/All of the courses have relevant additional resources which are very useful.
 
-<a id="" href="#ref">^</a>1 - Used as the reference for
+<a id="EOIT" href="#EOITref">^</a>1 - Used as the reference for
 
 - [15-859 at CMU](http://www.cs.cmu.edu/~venkatg/teaching/ITCS-spr2013/) with many other classic papers recommended for reading
 - [CSE 533 at UoW](https://catalyst.uw.edu/workspace/anuprao/15415/86593) with [a list of papers](https://catalyst.uw.edu/workspace/anuprao/15415/86644)
 - [EE5581 at UMN](http://people.ece.umn.edu/~nihar/ee5581_fall05/index.html)
 - [CSCI1850 at Brown](http://jwmi.github.io/IC/) with additional readings from **Information Theory, Inference, and Learning Algorithms** which is [available free of cost](http://www.inference.org.uk/mackay/itila/book.html)
 - [TTIC 31200/CMSC 37220 at UC](http://ttic.uchicago.edu/%7Emadhurt/courses/infotheory2014/index.html)
-- [10-704 at CMU](http://www.cs.cmu.edu/%7Eaarti/Class/10704/lecs.html) along with [2], and has elements of Machine Learning applied to it
+- [10-704 at CMU](http://www.cs.cmu.edu/%7Eaarti/Class/10704/lecs.html) along with [^](#ITILAref)2, and has elements of Machine Learning applied to it
 - [CS85/CS185 at Dartmouth](http://www.cs.dartmouth.edu/%7Eac/Teach/CS85-Winter06/) with [a list of papers](http://www.cs.dartmouth.edu/%7Eac/Teach/CS85-Winter06/#papers) for primary reading
 - [COS 597D at Princeton](http://www.cs.princeton.edu/courses/archive/fall11/cos597D/) which also recommends several papers
-- [COMPSCI 650 at UMass](https://people.cs.umass.edu/~elm/Teaching/650_F14/) with [2] recommended additionally
+- [COMPSCI 650 at UMass](https://people.cs.umass.edu/~elm/Teaching/650_F14/) with [^](#ITILAref)2 recommended additionally
 - [582650 at UoH](https://www.cs.helsinki.fi/group/cosco/Teaching/Information/2014/)
 - [CO 739-2 at UoW](http://www.math.uwaterloo.ca/~anayak/Site/Information_Theory.html)
 - [EECS 428 at NWU](https://www.mccormick.northwestern.edu/eecs/courses/descriptions/428.html) (Note: Syllabus page only)
 - [ECE 563 at UoI](https://ece.illinois.edu/academics/courses/profile/ece563) (Note: Syllabus page only)
 
-<a id="" href="#ref">^</a>2 - Used as a reference for
+<a id="ITILA" href="#ITILAref">^</a>2 - Used as a reference for
 
 - [COMP 7404 at DU](http://web.cs.du.edu/~ramki/courses/tpcs/infoTheory/index.html)
-- [CSC 310 at UoT](https://www.cs.toronto.edu/~radford/csc310.F11/) with [3] recommended for rigorous mathematical analysis
+- [CSC 310 at UoT](https://www.cs.toronto.edu/~radford/csc310.F11/) with [^](#EAITref)3 recommended for rigorous mathematical analysis
 - [CS 616 at WU](https://www.westminster.edu/resources/dean/view_course_syllabus.cfm?id=769) (Note: Syllabus page only)
 
 ## Compiler Design
 
 ### Standard Textbooks
 
-1. **Compilers: Principles, Techniques, and Tools** - A. V. Aho, Ravi Sethi & Jeffrey D. Ullman <sup id="ref">[[1]](#)</sup>
+1. **Compilers: Principles, Techniques, and Tools** - A. V. Aho, Ravi Sethi & Jeffrey D. Ullman (_The Dragon Book_) <sup id="TCDBref">[[1]](#TCDB)</sup>
 2. **Compiler Construction Principles and Practice** - K. C. Louden
-3. **Modern compiler implementation in ML** - A. W. Appel <sup id="ref">[[2]](#)</sup>
+3. **Modern Compiler Implementation in ML** - A. W. Appel <sup id="MCIMLref">[[2]](#MCIML)</sup>
 
 ### Alternative/Supplementary
 
@@ -673,13 +673,13 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Notes
 
-<a id="" href="#ref">^</a>1 - This is a brilliant book recommended by [pearson.com](https://www.pearson.com/us/higher-education/program/Aho-Compilers-Principles-Techniques-and-Tools-2nd-Edition/PGM167067.html). Used as the reference for
+<a id="TCDB" href="#TCDBref">^</a>1 - This is a brilliant book recommended by [pearson.com](https://www.pearson.com/us/higher-education/program/Aho-Compilers-Principles-Techniques-and-Tools-2nd-Edition/PGM167067.html). Used as the reference for
 
 - [CS143 at Stanford University](https://web.stanford.edu/class/cs143/)
 - [CS4120 at Cornell University](http://www.cs.cornell.edu/courses/cs4120/2013fa/)
 - [CS5470 at university of Utah](https://courses.engr.illinois.edu/cs421/fa2014/)
 
-<a id="" href="#ref">^</a>2 - Used as reference for
+<a id="MCIML" href="#MCIMLref">^</a>2 - Used as reference for
 
 - [CS421 at University of Illinois](https://courses.engr.illinois.edu/cs421/fa2014/)
 
@@ -687,55 +687,55 @@ Online courses about Microprocessors are rather difficult to come by.
 
 ### Standard Textbooks
 
-1. **Computer Networking: A Top-Down Approach** - James Kurose and Keith Ross <sup id="ref">[[1]](#)</sup>
-2. **Computer Networks – A System Approach** - Larry L. Peterson and Bruce S. Davie <sup id="ref">[[2]](#)</sup>
-3. **Computer Networks** - Andrew S. Tanenbaum <sup id="ref">[[3]](#)</sup>
+1. **Computer Networking: A Top-Down Approach** - James Kurose and Keith Ross <sup id="CNATDAref">[[1]](#CNATDA)</sup>
+2. **Computer Networks – A System Approach** - Larry L. Peterson and Bruce S. Davie <sup id="CNASDref">[[2]](#CNASD)</sup>
+3. **Computer Networks** - Andrew S. Tanenbaum <sup id="CNATref">[[3]](#CNAT)</sup>
 
 ### Alternative/Supplementary
 
-1. **TCP/IP protocol Suite** - Behrouz A. Forouzan
-2. **Data and Computer Communication** - William Stallings <sup id="ref">[[4]](#)</sup>
+1. **TCP/IP Protocol Suite** - Behrouz A. Forouzan
+2. **Data and Computer Communication** - William Stallings <sup id="DCCWSref">[[4]](#DCCWS)</sup>
 3. **Data Communication, Computer Networks and Open Systems** - F. Halsall
-4. **Data Communications and Networking** - Behrouz A. Forouzan <sup id="ref">[[5]](#)</sup>
+4. **Data Communications and Networking** - Behrouz A. Forouzan <sup id="DCNBFref">[[5]](#DCNBF)</sup>
 5. **Internetworking with TCP/IP, Volume 1** - Douglas Comer
-6. **TCP/IP Illustrated, Volume 1: The Protocols** - W. Richard Stevens <sup id="ref">[[6]](#)</sup>
-7. **Unix Network Programming, Volume 1: The Sockets Networking API** - W. Richard Stevens <sup id="ref">[[7]](#)</sup>
+6. **TCP/IP Illustrated, Volume 1: The Protocols** - W. Richard Stevens <sup id="TCPIPIref">[[6]](#TCPIPI)</sup>
+7. **Unix Network Programming, Volume 1: The Sockets Networking API** - W. Richard Stevens <sup id="UNPVOref">[[7]](#UNPVO)</sup>
 
 ### Notes
 
 [GATech's CS 6250](https://www.omscs.gatech.edu/cs-6250-computer-networks) has a list of useful papers [on Udacity](https://www.udacity.com/wiki/ud819/resources). There are also many more amazing resources on the web.
 
-<a id="" href="#ref">^</a>1 - It is recommended over at [TYCS](https://teachyourselfcs.com/#networking). Also used as the reference for
+<a id="CNATDA" href="#CNATDAref">^</a>1 - It is recommended over at [TYCS](https://teachyourselfcs.com/#networking). Also used as the reference for
 
 - [CS60 at Dartmouth](http://www.cs.dartmouth.edu/~campbell/cs60/) where texts on Shell Scripting like **A Practical Guide to Linux Commands, Editors, and Shell Programming** by Mark G. Sobell are also recommended
 - [CS 356 at UT Austin](http://www.cs.utexas.edu/users/lam/cs356/)
-- [COS 461 at Princeton](https://www.cs.princeton.edu/courses/archive/spring17/cos461/) along with [^](#)2
+- [COS 461 at Princeton](https://www.cs.princeton.edu/courses/archive/spring17/cos461/) along with [^](#CNASDref)2
 - [CS244A at Stanford](http://web.stanford.edu/class/cs244a/)
 
-<a id="" href="#ref">^</a>2 - Used as the reference for
+<a id="CNASD" href="#CNASDref">^</a>2 - Used as the reference for
 
 - [15-441 at CMU](https://www.cs.cmu.edu/~prs/15-441-F16/)
-- [Computer Networks at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/networks/) along with <sup id=ref"">[[3]](#)</sup>
+- [Computer Networks at Oxford](https://www.cs.ox.ac.uk/teaching/courses/2017-2018/networks/) along with [^](#CNATref)3
 - [CS 640 at UWISC](http://pages.cs.wisc.edu/~pb/cs640.html)
 
-<a id="" href="#ref">^</a>4 - Used as the reference for
+<a id="DCCWS" href="#DCCWSref">^</a>4 - Used as the reference for
 
 - [CS 408 at SU](http://people.sabanciuniv.edu/levi/cs408/)
 
-<a id="" href="#ref">^</a>5 - It is regarded as the standard textbook in the field [according to Wikipedia](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Networking).
+<a id="DCNBF" href="#DCNBFref">^</a>5 - It is regarded as the standard textbook in the field [according to Wikipedia](https://en.wikipedia.org/wiki/List_of_important_publications_in_computer_science#Networking).
 
-<a id="" href="#ref">^</a>6, [7] - Widely recommended in many courses listed above for additional reading, especially those at Princeton, Stanford and UWISC.
+<a id="TCPIPI" href="#TCPIPIref">^</a>6, <a id="UNPVO" href="#UNPVOref">^</a>7 - Widely recommended in many courses listed above for additional reading, especially those at Princeton, Stanford and UWISC.
 
 ## Software Engineering
 
 ### Standard Textbooks
 
-1. **Software Engineering A Practitioner’s Approach** - Roger S. Pressman <sup id="ref">[[1]](#)</sup>
-2. **Software Engineering** - Ian Sommerville <sup id="ref">[[2]](#)</sup>
+1. **Software Engineering: A Practitioner’s Approach** - Roger S. Pressman <sup id="SEAPAref">[[1]](#SEAPA)</sup>
+2. **Software Engineering** - Ian Sommerville <sup id="SEISref">[[2]](#SEIS)</sup>
 
 ### Alternative/Supplementary
 
-1. **An Integrated Approach to Software Engineering** - Pankaj Jalote <sup id="ref">[[3]](#)</sup>
+1. **An Integrated Approach to Software Engineering** - Pankaj Jalote <sup id="AIASEref">[[3]](#AIASE)</sup>
 2. **Software Engineering Fundamentals** - A. Behferooz and F. J. Hudson
 3. **Fundamentals of Software Engineering** - Rajib Mall
 4. **Software Engineering** - Gaurav Gupta and Deepika Gupta
@@ -743,57 +743,57 @@ Online courses about Microprocessors are rather difficult to come by.
 6. **Software Engineering 1st Edition** - Udit Agarwal
 7. **Algebraic Methodology and Software Technology** - Grigore Rosu and Jose Meseguer
 8. **Software Design Methodology: From Principles to Architectural Styles** - Hong Zhu
-9. **Object-oriented Software Engineering : using UML, patterns, and Java** - Bernd Bruegge and Allen Dutoit <sup id="ref">[[4]](#)</sup>
-10. **The New Software Engineering** - Sue A. Conger <sup id="ref">[[5]](#)</sup>
-11. **The Pragmatic Programmer** - Dave Thomas and Andy Hunt <sup id="ref">[[6]](#)</sup>
-12. **Software Engineering** - Ivan Marsic <sup id="ref">[[7]](#)</sup>
-13. **Design Patterns:  Elements of Reusable Object-Oriented Software**-  E. Gamma, R. Helm, R. Johnson, and J. Vlissides <sup id="ref">[[8]](#)</sup>
-14. **Object-Oriented Software Engineering: Practical Software Development using UML and Java** - Timothy C. Lethbridge and Robert Laganière <sup id="ref">[[9]](#)</sup>
-15. **Fundamentals of Software Engineering** - Carlo Ghezzi <sup id="ref">[[10]](#)</sup>
+9. **Object-oriented Software Engineering : using UML, patterns, and Java** - Bernd Bruegge and Allen Dutoit <sup id="OOSEref">[[4]](#OOSE)</sup>
+10. **The New Software Engineering** - Sue A. Conger <sup id="TNSESCref">[[5]](#TNSESC)</sup>
+11. **The Pragmatic Programmer** - Dave Thomas and Andy Hunt <sup id="TPPTHref">[[6]](#TPPTH)</sup>
+12. **Software Engineering** - Ivan Marsic <sup id="SEIMref">[[7]](#SEIM)</sup>
+13. **Design Patterns:  Elements of Reusable Object-Oriented Software**-  E. Gamma, R. Helm, R. Johnson, and J. Vlissides <sup id="DPEROOSref">[[8]](#DPEROOS)</sup>
+14. **Object-Oriented Software Engineering: Practical Software Development using UML and Java** - Timothy C. Lethbridge and Robert Laganière <sup id="OOSELLref">[[9]](#OOSELL)</sup>
+15. **Fundamentals of Software Engineering** - Carlo Ghezzi <sup id="FOSECGref">[[10]](#FOSECG)</sup>
 
 ### Notes
 
 - Wikipedia has a [list of notable publications](https://en.wikipedia.org/wiki/Outline_of_software_engineering#Notable_publications) in Software Engineering.
-- [CS32 at Brown](http://cs.brown.edu/courses/cs0320/) recommends **Effective Java** by Joshua Bloch for some reason. :shrug:
+- [CS32 at Brown](http://cs.brown.edu/courses/cs0320/) recommends **Effective Java** by Joshua Bloch for some reason.
 - [EE 360F at UT Austin](http://users.ece.utexas.edu/~perry/education/SE-Intro/) has a list of papers and sections from multiple books as necessary readings for the course.
 
-<a id="" href="#ref">^</a>1 - Used as the reference for
+<a id="SEAPA" href="#SEAPAref">^</a>1 - Used as the reference for
 
 - [15-413 at CMU](https://www.cs.cmu.edu/~aldrich/courses/413/)
 - [CS 501 at Cornell](http://www.cs.cornell.edu/courses/cs501/2000FA/index.html) along with other classic books like **The Mythical Man Month** by Frederick Brooks
 
-<a id="" href="#ref">^</a>2 - Used as the reference for
+<a id="SEIS" href="#SEISref">^</a>2 - Used as the reference for
 
 - [Introduction to Software Engineering at PSU](http://www.csci.psu.edu/seminars/fallnotes/SWEintro.pdf) (Note: Syllabus page only)
 
-<a id="" href="#ref">^</a>3 - Used as the reference for
+<a id="AIASE" href="#AIASEref">^</a>3 - Used as the reference for
 
 - [CS 320 at UMass](https://people.cs.umass.edu/~brun/class/2013Spring/CS320/)
 
-<a id="" href="#ref">^</a>4 - Used as the reference for
+<a id="OOSE" href="#OOSEref">^</a>4 - Used as the reference for
 
 - [CS223 at Warwick](http://web.iitd.ac.in/~sumeet/sm.pdf) (Note: Syllabus and lecture pdf only)
 
-<a id="" href="#ref">^</a>5 - Used as the reference for
+<a id="TNSESC" href="#TNSESCref">^</a>5 - Used as the reference for
 
 - [CS302 at Saylor Academy](https://learn.saylor.org/mod/page/view.php?id=686)
 
-<a id="" href="#ref">^</a>6 - Used as the reference for
+<a id="TPPTH" href="#TPPTHref">^</a>6 - Used as the reference for
 
 - [CSE 403 at UoW](https://courses.cs.washington.edu/courses/cse403/)
 
-<a id="" href="#ref">^</a>7 - A [free book](http://www.ece.rutgers.edu/~marsic/books/SE/book-SE_marsic.pdf) written by the instructor of [ECE 14:332:452 at Rutgers](http://www.ece.rutgers.edu/~marsic/Teaching/SE/).
+<a id="SEIM" href="#SEIMref">^</a>7 - A [free book](http://www.ece.rutgers.edu/~marsic/books/SE/book-SE_marsic.pdf) written by the instructor of [ECE 14:332:452 at Rutgers](http://www.ece.rutgers.edu/~marsic/Teaching/SE/).
 
-<a id="" href="#ref">^</a>8 - Used as the reference for
+<a id="DPEROOS" href="#DPEROOSref">^</a>8 - Used as the reference for
 
 - [CSE870 at MSU](http://www.cse.msu.edu/~cse870/index.php) along with many other articles from literature
 - [Foundations of Software Engineering at BGU](https://www.cs.bgu.ac.il/~fsen141/Main) along with many other textbooks
 
-<a id="" href="#ref">^</a>9 - Used as the reference for
+<a id="OOSELL" href="#OOSELLref">^</a>9 - Used as the reference for
 
 - SEG 2100 at UoO which cannot be accessed. Instead the author provides supporting materials and other links [here](http://www.site.uottawa.ca/school/research/lloseng/).
 
-<a id="" href="#ref">^</a>10 - Used as the reference for
+<a id="FOSECG" href="#FOSECGref">^</a>10 - Used as the reference for
 
 - [CSE2102 at UConn](http://www.engr.uconn.edu/~steve/Cse2102/cse2102.html)
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This repository was created to maintain a comprehensive list of textbooks and us
 # CS Curriculum Textbooks and References
 Being an avid book reader, I have found it absurdly difficult to find a comprehensive list of textbooks to use for reference and/or self learning. I have, therefore, set out to create and share it for all who wish to find the same. I have also linked courses that I could find across the web, most often the links from the first two pages of Googling, so that one may find a relevant guide to the particular topic. All linked course pages often have one or more additional references should the reader wish to explore the topic in greater depth. This list is by no means comprehensive, though it is an eventual target. There are also video lectures of many of courses which are better located at [Computer Science courses with video lectures](https://github.com/Developer-Y/cs-video-courses).
 
-- [Data Structure and Algorithms](Curriculum.md/#data-structure-and-algorithms)
+- [Data Structures and Algorithms](Curriculum.md/#data-structures-and-algorithms)
 - [Database Management Systems](Curriculum.md/#database-management-systems)
 - [Principles of Programming Languages](Curriculum.md/#principles-of-programming-languages)
 - [Computer Organisation and Architecture](Curriculum.md/#computer-organisation-and-architecture)


### PR DESCRIPTION
I am very much a fan of Wikipedia's style of article referencing which makes it easier to navigate between relevant sections of a document, especially on mobile. Since that couldn't be natively done in GFM, I decided to go with embedding inline HTML in the document. Although I realise that there are other tools to serve this purpose, such as Pandoc and what not, I found that they offer too many options and require more effort than I would prefer. This also consequently changes the Pull Request template which will now require more effort from the contributor in exchange for enhanced readability. It will be updated in due time. 